### PR TITLE
[FIX] ensure controlled terms have identifiers

### DIFF
--- a/bagel/bids_utils.py
+++ b/bagel/bids_utils.py
@@ -42,7 +42,7 @@ def create_acquisitions(
         if mapped_term:
             image_list.append(
                 models.Acquisition(
-                    hasContrastType=models.Image(identifier=mapped_term)
+                    hasContrastType=models.ControlledTerm(identifier=mapped_term, schemaKey="Image")
                 )
             )
 

--- a/bagel/cli.py
+++ b/bagel/cli.py
@@ -90,7 +90,7 @@ def pheno(
             elif _dx_val == mappings.NEUROBAGEL["healthy_control"]:
                 subject.isSubjectGroup = mappings.NEUROBAGEL["healthy_control"]
             else:
-                subject.diagnosis = [models.Diagnosis(identifier=_dx_val)]
+                subject.diagnosis = [models.ControlledTerm(identifier=_dx_val, schemaKey="Diagnosis")]
 
         if "age" in column_mapping.keys():
             subject.age = putil.get_transformed_values(

--- a/bagel/cli.py
+++ b/bagel/cli.py
@@ -77,9 +77,9 @@ def pheno(
 
         subject = models.Subject(label=str(participant))
         if "sex" in column_mapping.keys():
-            subject.sex = putil.get_transformed_values(
+            subject.sex = models.ControlledTerm(identifier=putil.get_transformed_values(
                 column_mapping["sex"], _sub_pheno, data_dictionary
-            )
+            ), schemaKey="Sex")
 
         if "diagnosis" in column_mapping.keys():
             _dx_val = putil.get_transformed_values(

--- a/bagel/cli.py
+++ b/bagel/cli.py
@@ -77,9 +77,12 @@ def pheno(
 
         subject = models.Subject(label=str(participant))
         if "sex" in column_mapping.keys():
-            subject.sex = models.ControlledTerm(identifier=putil.get_transformed_values(
-                column_mapping["sex"], _sub_pheno, data_dictionary
-            ), schemaKey="Sex")
+            subject.sex = models.ControlledTerm(
+                identifier=putil.get_transformed_values(
+                    column_mapping["sex"], _sub_pheno, data_dictionary
+                ),
+                schemaKey="Sex",
+            )
 
         if "diagnosis" in column_mapping.keys():
             _dx_val = putil.get_transformed_values(
@@ -88,9 +91,16 @@ def pheno(
             if _dx_val is None:
                 pass
             elif _dx_val == mappings.NEUROBAGEL["healthy_control"]:
-                subject.isSubjectGroup = mappings.NEUROBAGEL["healthy_control"]
+                subject.isSubjectGroup = models.ControlledTerm(
+                    identifier=mappings.NEUROBAGEL["healthy_control"],
+                    schemaKey="SubjectGroup",
+                )
             else:
-                subject.diagnosis = [models.ControlledTerm(identifier=_dx_val, schemaKey="Diagnosis")]
+                subject.diagnosis = [
+                    models.ControlledTerm(
+                        identifier=_dx_val, schemaKey="Diagnosis"
+                    )
+                ]
 
         if "age" in column_mapping.keys():
             subject.age = putil.get_transformed_values(

--- a/bagel/cli.py
+++ b/bagel/cli.py
@@ -99,7 +99,7 @@ def pheno(
 
         if tool_mapping:
             _assessments = [
-                models.Assessment(identifier=tool)
+                models.ControlledTerm(identifier=tool, schemaKey="Assessment")
                 for tool, columns in tool_mapping.items()
                 if putil.are_not_missing(columns, _sub_pheno, data_dictionary)
             ]

--- a/bagel/models.py
+++ b/bagel/models.py
@@ -22,8 +22,13 @@ class Image(BaseModel, extra=Extra.forbid):
     schemaKey: Literal["Image"] = "Image"
 
 
+class ControlledTerm(BaseModel):
+    identifier: Union[str, HttpUrl]
+    schemaKey: str
+
+
 class Acquisition(Bagel):
-    hasContrastType: Image
+    hasContrastType: ControlledTerm
     schemaKey: Literal["Acquisition"] = "Acquisition"
 
 
@@ -48,10 +53,10 @@ class Subject(Bagel):
     label: str
     hasSession: Optional[List[Session]] = None
     age: Optional[float] = None
-    sex: Optional[str] = None
-    isSubjectGroup: Optional[str] = None
-    diagnosis: Optional[List[Diagnosis]] = None
-    assessment: Optional[List[Assessment]] = None
+    sex: Optional[ControlledTerm] = None
+    isSubjectGroup: Optional[ControlledTerm] = None
+    diagnosis: Optional[List[ControlledTerm]] = None
+    assessment: Optional[List[ControlledTerm]] = None
     schemaKey: Literal["Subject"] = "Subject"
 
 

--- a/bagel/models.py
+++ b/bagel/models.py
@@ -17,11 +17,6 @@ class Bagel(BaseModel, extra=Extra.forbid):
     )
 
 
-class Image(BaseModel, extra=Extra.forbid):
-    identifier: str
-    schemaKey: Literal["Image"] = "Image"
-
-
 class ControlledTerm(BaseModel):
     identifier: Union[str, HttpUrl]
     schemaKey: str

--- a/bagel/models.py
+++ b/bagel/models.py
@@ -32,16 +32,6 @@ class Acquisition(Bagel):
     schemaKey: Literal["Acquisition"] = "Acquisition"
 
 
-class Diagnosis(BaseModel, extra=Extra.forbid):
-    identifier: Union[str, HttpUrl]
-    schemaKey: Literal["Diagnosis"] = "Diagnosis"
-
-
-class Assessment(BaseModel, extra=Extra.forbid):
-    identifier: Union[str, HttpUrl]
-    schemaKey: Literal["Assessment"] = "Assessment"
-
-
 class Session(Bagel):
     label: str
     filePath: Optional[str] = None

--- a/bagel/tests/data/example_synthetic.jsonld
+++ b/bagel/tests/data/example_synthetic.jsonld
@@ -9,9 +9,9 @@
       "@id": "bg:hasContrastType"
     },
     "schemaKey": "@type",
-    "Assessment": "bg:Assessment",
     "Bagel": "bg:Bagel",
     "BaseModel": "bg:BaseModel",
+    "ControlledTerm": "bg:ControlledTerm",
     "Dataset": "bg:Dataset",
     "label": {
       "@id": "bg:label"
@@ -19,7 +19,6 @@
     "hasSamples": {
       "@id": "bg:hasSamples"
     },
-    "Diagnosis": "bg:Diagnosis",
     "Image": "bg:Image",
     "Session": "bg:Session",
     "filePath": {
@@ -48,15 +47,21 @@
       "@id": "bg:assessment"
     }
   },
-  "identifier": "bg:bc413741-695a-4e42-b13b-8644ae59e455",
-  "label": "BIDS synthetic example dataset",
+  "identifier": "bg:d6da97be-3788-4865-824c-5bfd0dd09ebe",
+  "label": "BIDS synthetic",
   "hasSamples": [
     {
-      "identifier": "bg:1884e35e-27d9-4479-822f-e80b1eff3622",
+      "identifier": "bg:a63aaaed-5abe-494c-8ad5-8cb84f44cf72",
       "label": "sub-01",
       "age": 34.1,
-      "sex": "bids:Female",
-      "isSubjectGroup": "purl:NCIT_C94342",
+      "sex": {
+        "identifier": "bids:Female",
+        "schemaKey": "Sex"
+      },
+      "isSubjectGroup": {
+        "identifier": "purl:NCIT_C94342",
+        "schemaKey": "SubjectGroup"
+      },
       "assessment": [
         {
           "identifier": "cogAtlas:1234",
@@ -70,10 +75,13 @@
       "schemaKey": "Subject"
     },
     {
-      "identifier": "bg:5bdf1e85-7837-4f5f-97c8-40dcba970285",
+      "identifier": "bg:57a0edd2-bbed-471e-8f67-0dca88ed58e5",
       "label": "sub-02",
       "age": 38.1,
-      "sex": "bids:Male",
+      "sex": {
+        "identifier": "bids:Male",
+        "schemaKey": "Sex"
+      },
       "diagnosis": [
         {
           "identifier": "snomed:49049000",
@@ -89,11 +97,17 @@
       "schemaKey": "Subject"
     },
     {
-      "identifier": "bg:baf6b7bd-7bbc-4963-aea8-bad00d8f2028",
+      "identifier": "bg:5e5bbec0-4625-480d-9aaf-0471b242b9d9",
       "label": "sub-03",
       "age": 22.1,
-      "sex": "bids:Male",
-      "isSubjectGroup": "purl:NCIT_C94342",
+      "sex": {
+        "identifier": "bids:Male",
+        "schemaKey": "Sex"
+      },
+      "isSubjectGroup": {
+        "identifier": "purl:NCIT_C94342",
+        "schemaKey": "SubjectGroup"
+      },
       "assessment": [
         {
           "identifier": "cogAtlas:1234",
@@ -103,11 +117,17 @@
       "schemaKey": "Subject"
     },
     {
-      "identifier": "bg:4abdd0a5-e16c-48df-afd2-7570bcf10fca",
+      "identifier": "bg:b595fe1c-7202-48a9-80a4-d1b59cc2cb17",
       "label": "sub-04",
       "age": 21.1,
-      "sex": "bids:Female",
-      "isSubjectGroup": "purl:NCIT_C94342",
+      "sex": {
+        "identifier": "bids:Female",
+        "schemaKey": "Sex"
+      },
+      "isSubjectGroup": {
+        "identifier": "purl:NCIT_C94342",
+        "schemaKey": "SubjectGroup"
+      },
       "assessment": [
         {
           "identifier": "cogAtlas:4321",
@@ -117,10 +137,13 @@
       "schemaKey": "Subject"
     },
     {
-      "identifier": "bg:df44b5f1-f7c5-41cc-befa-c6026b3c12d9",
+      "identifier": "bg:d5e885b0-98e9-461e-be7c-3e9b8d093984",
       "label": "sub-05",
       "age": 42.5,
-      "sex": "bids:Male",
+      "sex": {
+        "identifier": "bids:Male",
+        "schemaKey": "Sex"
+      },
       "diagnosis": [
         {
           "identifier": "snomed:49049000",

--- a/bagel/tests/test_cli_pheno.py
+++ b/bagel/tests/test_cli_pheno.py
@@ -119,6 +119,32 @@ def test_diagnosis_and_control_status_handled(
     assert pheno["hasSamples"][2]["isSubjectGroup"] == "purl:NCIT_C94342"
 
 
+@pytest.mark.parametrize("attribute", [
+    "sex"
+])
+def test_controlled_terms_have_identifiers(attribute, runner, test_data, tmp_path, load_test_json
+):
+    result = runner.invoke(
+        bagel,
+        [
+            "pheno",
+            "--pheno",
+            test_data / "example_synthetic.tsv",
+            "--dictionary",
+            test_data / "example_synthetic.json",
+            "--output",
+            tmp_path,
+            "--name",
+            "do not care name",
+        ],
+    )
+
+    pheno = load_test_json(tmp_path / "pheno.jsonld")
+    assert all([
+        "identifier" in sub.get(attribute) for sub in pheno["hasSamples"] if attribute in sub.keys()
+    ])
+
+
 @pytest.mark.parametrize(
     "assessment, subject",
     [

--- a/bagel/tests/test_cli_pheno.py
+++ b/bagel/tests/test_cli_pheno.py
@@ -119,10 +119,9 @@ def test_diagnosis_and_control_status_handled(
     assert pheno["hasSamples"][2]["isSubjectGroup"] == "purl:NCIT_C94342"
 
 
-@pytest.mark.parametrize("attribute", [
-    "sex"
-])
-def test_controlled_terms_have_identifiers(attribute, runner, test_data, tmp_path, load_test_json
+@pytest.mark.parametrize("attribute", ["sex", "diagnosis"])
+def test_controlled_terms_have_identifiers(
+    attribute, runner, test_data, tmp_path, load_test_json
 ):
     result = runner.invoke(
         bagel,
@@ -140,9 +139,15 @@ def test_controlled_terms_have_identifiers(attribute, runner, test_data, tmp_pat
     )
 
     pheno = load_test_json(tmp_path / "pheno.jsonld")
-    assert all([
-        "identifier" in sub.get(attribute) for sub in pheno["hasSamples"] if attribute in sub.keys()
-    ])
+
+    for sub in pheno["hasSamples"]:
+        if attribute in sub.keys():
+            value = sub.get(attribute)
+            if not isinstance(value, list):
+                value = [value]
+            assert all(
+                ["identifier" in entry for entry in value]
+            ), f"{attribute}: did not have an identifier for subject {sub} and value {value}"
 
 
 @pytest.mark.parametrize(

--- a/bagel/tests/test_cli_pheno.py
+++ b/bagel/tests/test_cli_pheno.py
@@ -116,10 +116,12 @@ def test_diagnosis_and_control_status_handled(
     )
     assert "diagnosis" not in pheno["hasSamples"][1].keys()
     assert "diagnosis" not in pheno["hasSamples"][2].keys()
-    assert pheno["hasSamples"][2]["isSubjectGroup"] == "purl:NCIT_C94342"
+    assert pheno["hasSamples"][2]["isSubjectGroup"]["identifier"] == "purl:NCIT_C94342"
 
 
-@pytest.mark.parametrize("attribute", ["sex", "diagnosis", "assessment"])
+@pytest.mark.parametrize(
+    "attribute", ["sex", "diagnosis", "assessment", "isSubjectGroup"]
+)
 def test_controlled_terms_have_identifiers(
     attribute, runner, test_data, tmp_path, load_test_json
 ):

--- a/bagel/tests/test_cli_pheno.py
+++ b/bagel/tests/test_cli_pheno.py
@@ -119,7 +119,7 @@ def test_diagnosis_and_control_status_handled(
     assert pheno["hasSamples"][2]["isSubjectGroup"] == "purl:NCIT_C94342"
 
 
-@pytest.mark.parametrize("attribute", ["sex", "diagnosis"])
+@pytest.mark.parametrize("attribute", ["sex", "diagnosis", "assessment"])
 def test_controlled_terms_have_identifiers(
     attribute, runner, test_data, tmp_path, load_test_json
 ):

--- a/bagel/tests/test_utility.py
+++ b/bagel/tests/test_utility.py
@@ -159,8 +159,6 @@ def test_invalid_age_heuristic():
         ("Bagel", ["identifier"]),
         ("Image", ["identifier", "schemaKey"]),
         ("Acquisition", ["hasContrastType", "schemaKey"]),
-        ("Diagnosis", ["identifier", "schemaKey"]),
-        ("Assessment", ["identifier", "schemaKey"]),
         ("Session", ["label", "filePath", "hasAcquisition", "schemaKey"]),
         (
             "Subject",

--- a/bagel/tests/test_utility.py
+++ b/bagel/tests/test_utility.py
@@ -157,7 +157,6 @@ def test_invalid_age_heuristic():
     "model, attributes",
     [
         ("Bagel", ["identifier"]),
-        ("Image", ["identifier", "schemaKey"]),
         ("Acquisition", ["hasContrastType", "schemaKey"]),
         ("Session", ["label", "filePath", "hasAcquisition", "schemaKey"]),
         (


### PR DESCRIPTION
Closes #110 

As part of this PR, the `example_synthetic.jsonld` test target had to be re-generated because the data model has changed, and the old  target file therefore wouldn't pass validation. I did a quick visual check, but would be good to check this again - after all it's a bit circular.