### PR TITLE
Implement checks for unannotated categorical column values + unused annotated missing values

### DIFF
--- a/bagel/pheno_utils.py
+++ b/bagel/pheno_utils.py
@@ -196,8 +196,9 @@ def find_undefined_categorical_column_values(
     data_dict: dict, pheno_df: pd.DataFrame
 ) -> dict:
     """
-    Returns a dictionary containing any categorical column names and specific column values not defined
-    in the corresponding data dictionary entry.
+    Checks that all categorical column values have annotations. Returns a dictionary containing
+    any categorical column names and specific column values not defined in the corresponding data
+    dictionary entry.
     """
     all_undefined_values = {}
     for col in data_dict.keys():
@@ -269,18 +270,18 @@ def validate_inputs(data_dict: dict, pheno_df: pd.DataFrame) -> None:
         raise LookupError(
             "The provided data dictionary and phenotypic file are individually valid, "
             "but are not compatible. Make sure that you selected the correct data "
-            "dictionary for your phenotyic file. Every column described in the data "
+            "dictionary for your phenotypic file. Every column described in the data "
             "dictionary has to have a corresponding column with the same name in the "
             "phenotypic file"
         )
 
-    unknown_categorical_col_values = find_undefined_categorical_column_values(
-        data_dict, pheno_df
+    undefined_categorical_col_values = (
+        find_undefined_categorical_column_values(data_dict, pheno_df)
     )
-    if unknown_categorical_col_values:
+    if undefined_categorical_col_values:
         raise LookupError(
-            "Categorical column(s) in the phenotypic .tsv have values not found in the provided data dictionary "
-            f"(shown as <column_name>: {{<undefined values>}}): {unknown_categorical_col_values}. "
+            "Categorical column(s) in the phenotypic file have values not found in the data dictionary "
+            f"(shown as <column_name>: {{<undefined values>}}): {undefined_categorical_col_values}. "
             "Please check that the correct data dictionary has been selected."
         )
 

--- a/bagel/tests/data/README.md
+++ b/bagel/tests/data/README.md
@@ -13,5 +13,7 @@ Example inputs to the CLI
 | invalid | valid, only exists to be used together with the (invalid) .json    | invalid, missing the `"TermURL"` attribute for identifiers                       | fail   |
 | 7       | has fewer columns than are annotated in `.json`                    | same as example 1                                                                | fail   |
 | 8       | valid, based on ex2 has multiple participant_id columns            | valid, based on ex2 multiple participant_id column annotations                   | fail*  |
+| 9       | valid, same as example 6            | invalid, based on example 6 but contains an unannotated value for `group`                   | fail  |
+| 10       | valid, based on example 6 but contains extra `"MissingValues"` not found in the .tsv           | valid, same as example 6                   | pass, with warning  |
 
 `* this is expected to fail until we enable multiple participant_ID handling`.

--- a/bagel/tests/data/example10.json
+++ b/bagel/tests/data/example10.json
@@ -1,0 +1,86 @@
+{
+    "participant_id": {
+        "Description": "A participant ID",
+        "Annotations": {
+            "IsAbout": {
+                "TermURL": "bg:ParticipantID",
+                "Label": "Unique participant identifier"
+            }
+        }
+    },
+    "session_id": {
+        "Description": "A session ID",
+        "Annotations": {
+            "IsAbout": {
+                "TermURL": "bg:SessionID",
+                "Label": "Unique session identifier"
+            }
+        }
+    },
+    "group": {
+        "Description": "Group variable",
+        "Levels": {
+            "PAT": "Patient",
+            "CTRL": "Control subject"
+        },
+        "Annotations": {
+            "IsAbout": {
+                "TermURL": "bg:diagnosis",
+                "Label": "Diagnosis"
+            },
+            "Levels": {
+                "PAT": {
+                    "TermURL": "snomed:49049000",
+                    "Label": "Parkinson's disease"
+                },
+                "CTRL": {
+                    "TermURL": "purl:NCIT_C94342",
+                    "Label": "Healthy Control"
+                }
+            },
+            "MissingValues": ["OTHER", "MISSING"]
+        }
+    },
+    "tool_item1": {
+        "Description": "item 1 scores for an imaginary tool",
+        "Annotations": {
+            "IsAbout": {
+                "TermURL": "bg:Assessment",
+                "Label": "Assessment tool"
+            },
+            "IsPartOf": {
+                "TermURL": "cogAtlas:1234",
+                "Label": "Imaginary tool"
+            },
+            "MissingValues": ["missing", "none", ""]
+        }
+    },
+    "tool_item2": {
+        "Description": "item 2 scores for an imaginary tool",
+        "Annotations": {
+            "IsAbout": {
+                "TermURL": "bg:Assessment",
+                "Label": "Assessment tool"
+            },
+            "IsPartOf": {
+                "TermURL": "cogAtlas:1234",
+                "Label": "Imaginary tool"
+            },
+            "MissingValues": ["missing", "none", ""]
+        }
+    },
+    "other_tool_item1": {
+        "Description": "item 1 scores for a different imaginary tool",
+        "Annotations": {
+            "IsAbout": {
+                "TermURL": "bg:Assessment",
+                "Label": "Assessment tool"
+            },
+            "IsPartOf": {
+                "TermURL": "cogAtlas:4321",
+                "Label": "A different imaginary tool"
+            },
+            "MissingValues": ["none"]
+        }
+    }
+}

--- a/bagel/tests/data/example10.tsv
+++ b/bagel/tests/data/example10.tsv
@@ -1,0 +1,7 @@
+participant_id	session_id	group	tool_item1	tool_item2	other_tool_item1
+sub-01	ses-01	PAT	11.0	"missing"	"none"
+sub-01	ses-02	PAT	"missing"	12.0	"none"
+sub-02	ses-01	OTHER	"missing"	"missing"	"none"
+sub-02	ses-02	OTHER	"missing"	"missing"	"none"
+sub-03	ses-01	CTRL	10.0	8.0	"ok"
+sub-03	ses-02	CTRL	10.0	8.0	"bad"

--- a/bagel/tests/data/example9.json
+++ b/bagel/tests/data/example9.json
@@ -1,0 +1,86 @@
+{
+    "participant_id": {
+        "Description": "A participant ID",
+        "Annotations": {
+            "IsAbout": {
+                "TermURL": "bg:ParticipantID",
+                "Label": "Unique participant identifier"
+            }
+        }
+    },
+    "session_id": {
+        "Description": "A session ID",
+        "Annotations": {
+            "IsAbout": {
+                "TermURL": "bg:SessionID",
+                "Label": "Unique session identifier"
+            }
+        }
+    },
+    "group": {
+        "Description": "Group variable",
+        "Levels": {
+            "PAT": "Patient",
+            "CTRL": "Control subject"
+        },
+        "Annotations": {
+            "IsAbout": {
+                "TermURL": "bg:diagnosis",
+                "Label": "Diagnosis"
+            },
+            "Levels": {
+                "PAT": {
+                    "TermURL": "snomed:49049000",
+                    "Label": "Parkinson's disease"
+                },
+                "CTRL": {
+                    "TermURL": "purl:NCIT_C94342",
+                    "Label": "Healthy Control"
+                }
+            },
+            "MissingValues": ["OTHER"]
+        }
+    },
+    "tool_item1": {
+        "Description": "item 1 scores for an imaginary tool",
+        "Annotations": {
+            "IsAbout": {
+                "TermURL": "bg:Assessment",
+                "Label": "Assessment tool"
+            },
+            "IsPartOf": {
+                "TermURL": "cogAtlas:1234",
+                "Label": "Imaginary tool"
+            },
+            "MissingValues": ["missing"]
+        }
+    },
+    "tool_item2": {
+        "Description": "item 2 scores for an imaginary tool",
+        "Annotations": {
+            "IsAbout": {
+                "TermURL": "bg:Assessment",
+                "Label": "Assessment tool"
+            },
+            "IsPartOf": {
+                "TermURL": "cogAtlas:1234",
+                "Label": "Imaginary tool"
+            },
+            "MissingValues": ["missing"]
+        }
+    },
+    "other_tool_item1": {
+        "Description": "item 1 scores for a different imaginary tool",
+        "Annotations": {
+            "IsAbout": {
+                "TermURL": "bg:Assessment",
+                "Label": "Assessment tool"
+            },
+            "IsPartOf": {
+                "TermURL": "cogAtlas:4321",
+                "Label": "A different imaginary tool"
+            },
+            "MissingValues": ["none"]
+        }
+    }
+}

--- a/bagel/tests/data/example9.tsv
+++ b/bagel/tests/data/example9.tsv
@@ -1,0 +1,9 @@
+participant_id	session_id	group	tool_item1	tool_item2	other_tool_item1
+sub-01	ses-01	PAT	11.0	"missing"	"none"
+sub-01	ses-02	PAT	"missing"	12.0	"none"
+sub-02	ses-01	OTHER	"missing"	"missing"	"none"
+sub-02	ses-02	OTHER	"missing"	"missing"	"none"
+sub-03	ses-01	CTRL	10.0	8.0	"ok"
+sub-03	ses-02	CTRL	10.0	8.0	"bad"
+sub-04	ses-01	SIB	12.0	9.0	"ok"
+sub-04	ses-02	SIB	12.0	9.0	"bad"

--- a/bagel/tests/test_cli_pheno.py
+++ b/bagel/tests/test_cli_pheno.py
@@ -41,6 +41,11 @@ def test_pheno_valid_inputs_run_successfully(
         ),
         ("example7", LookupError, "not compatible"),
         ("example8", ValueError, "more than one column"),
+        (
+            "example9",
+            LookupError,
+            "values not found in the provided data dictionary (shown as <column_name>: {<undefined values>}): {'group': {'SIB'}}",
+        ),
     ],
 )
 def test_invalid_inputs_are_handled_gracefully(
@@ -116,7 +121,10 @@ def test_diagnosis_and_control_status_handled(
     )
     assert "diagnosis" not in pheno["hasSamples"][1].keys()
     assert "diagnosis" not in pheno["hasSamples"][2].keys()
-    assert pheno["hasSamples"][2]["isSubjectGroup"]["identifier"] == "purl:NCIT_C94342"
+    assert (
+        pheno["hasSamples"][2]["isSubjectGroup"]["identifier"]
+        == "purl:NCIT_C94342"
+    )
 
 
 @pytest.mark.parametrize(
@@ -125,7 +133,7 @@ def test_diagnosis_and_control_status_handled(
 def test_controlled_terms_have_identifiers(
     attribute, runner, test_data, tmp_path, load_test_json
 ):
-    result = runner.invoke(
+    runner.invoke(
         bagel,
         [
             "pheno",

--- a/bagel/tests/test_cli_pheno.py
+++ b/bagel/tests/test_cli_pheno.py
@@ -72,6 +72,39 @@ def test_invalid_inputs_are_handled_gracefully(
     assert expected_message in str(e.value)
 
 
+def test_unused_missing_values_raises_warning(
+    runner,
+    test_data,
+    tmp_path,
+):
+    """
+    Tests that an informative warning is raised when annotated missing values are not found in the
+    phenotypic file.
+    """
+    with pytest.warns(UserWarning) as w:
+        runner.invoke(
+            bagel,
+            [
+                "pheno",
+                "--pheno",
+                test_data / "example10.tsv",
+                "--dictionary",
+                test_data / "example10.json",
+                "--output",
+                tmp_path,
+                "--name",
+                "testing dataset",
+            ],
+            catch_exceptions=False,
+        )
+
+    assert len(w) == 1
+    assert (
+        "missing values in the data dictionary were not found in the corresponding phenotypic file column(s) "
+        "(<column_name>: [<unused missing values>]): {'group': ['MISSING'], 'tool_item1': ['none', ''], 'tool_item2': ['none', '']}"
+    ) in str(w[0].message.args[0])
+
+
 def test_that_output_file_contains_name(
     runner, test_data, tmp_path, load_test_json
 ):

--- a/bagel/tests/test_cli_pheno.py
+++ b/bagel/tests/test_cli_pheno.py
@@ -44,7 +44,7 @@ def test_pheno_valid_inputs_run_successfully(
         (
             "example9",
             LookupError,
-            "values not found in the data dictionary (shown as <column_name>: {<undefined values>}): {'group': {'SIB'}}",
+            "values not found in the data dictionary (shown as <column_name>: [<undefined values>]): {'group': ['SIB']}",
         ),
     ],
 )

--- a/bagel/tests/test_cli_pheno.py
+++ b/bagel/tests/test_cli_pheno.py
@@ -44,7 +44,7 @@ def test_pheno_valid_inputs_run_successfully(
         (
             "example9",
             LookupError,
-            "values not found in the provided data dictionary (shown as <column_name>: {<undefined values>}): {'group': {'SIB'}}",
+            "values not found in the data dictionary (shown as <column_name>: {<undefined values>}): {'group': {'SIB'}}",
         ),
     ],
 )


### PR DESCRIPTION
Fixes #107, fixes #109 

Two new examples also added for testing, example 9 (.tsv has unannotated categorical column values) and 10 (.json has unused `"MissingValues"`). Minor noticed typos also fixed.


