### PR TITLE
Align terms to naming standards, refactor use of namespaces

### DIFF
--- a/bagel/cli.py
+++ b/bagel/cli.py
@@ -77,7 +77,7 @@ def pheno(
 
         subject = models.Subject(hasLabel=str(participant))
         if "sex" in column_mapping.keys():
-            subject.sex = models.ControlledTerm(
+            subject.hasSex = models.ControlledTerm(
                 identifier=putil.get_transformed_values(
                     column_mapping["sex"], _sub_pheno, data_dictionary
                 ),
@@ -96,14 +96,14 @@ def pheno(
                     schemaKey="SubjectGroup",
                 )
             else:
-                subject.diagnosis = [
+                subject.hasDiagnosis = [
                     models.ControlledTerm(
                         identifier=_dx_val, schemaKey="Diagnosis"
                     )
                 ]
 
         if "age" in column_mapping.keys():
-            subject.age = putil.get_transformed_values(
+            subject.hasAge = putil.get_transformed_values(
                 column_mapping["age"], _sub_pheno, data_dictionary
             )
 
@@ -115,7 +115,7 @@ def pheno(
             ]
             if _assessments:
                 # Only set assignments for the subject if at least one is not missing
-                subject.assessment = _assessments
+                subject.hasAssessment = _assessments
 
         subject_list.append(subject)
 
@@ -167,7 +167,7 @@ def bids(
         print(err)
 
     pheno_subject_dict = {
-        pheno_subject.label: pheno_subject
+        pheno_subject.hasLabel: pheno_subject
         for pheno_subject in getattr(pheno_dataset, "hasSamples")
     }
     bids_subject_list = ["sub-" + sub_id for sub_id in layout.get_subjects()]

--- a/bagel/cli.py
+++ b/bagel/cli.py
@@ -75,7 +75,7 @@ def pheno(
             f"{participants} == '{str(participant)}'"
         ).iloc[0]
 
-        subject = models.Subject(label=str(participant))
+        subject = models.Subject(hasLabel=str(participant))
         if "sex" in column_mapping.keys():
             subject.sex = models.ControlledTerm(
                 identifier=putil.get_transformed_values(
@@ -119,7 +119,7 @@ def pheno(
 
         subject_list.append(subject)
 
-    dataset = models.Dataset(label=name, hasSamples=subject_list)
+    dataset = models.Dataset(hasLabel=name, hasSamples=subject_list)
     context = putil.generate_context()
     # We can't just exclude_unset here because the identifier and schemaKey
     # for each instance are created as default values and so technically are never set
@@ -217,8 +217,8 @@ def bids(
             session_list.append(
                 # Add back "ses" prefix because pybids stripped it
                 models.Session(
-                    label="ses-" + session_label,
-                    filePath=session_path,
+                    hasLabel="ses-" + session_label,
+                    hasFilePath=session_path,
                     hasAcquisition=image_list,
                 )
             )

--- a/bagel/mappings.py
+++ b/bagel/mappings.py
@@ -12,11 +12,11 @@ BIDS = {
     "asl": "nidm:ArterialSpinLabeling",
 }
 NEUROBAGEL = {
-    "participant": "bg:ParticipantID",
-    "session": "bg:SessionID",
-    "sex": "bg:sex",
-    "age": "bg:Age",
-    "diagnosis": "bg:diagnosis",
+    "participant": "nb:ParticipantID",  # TODO: Add to graph?
+    "session": "nb:SessionID",  # TODO: Add to graph?
+    "sex": "nb:Sex",
+    "age": "nb:Age",
+    "diagnosis": "nb:Diagnosis",
     "healthy_control": "purl:NCIT_C94342",
-    "assessment_tool": "bg:Assessment",
+    "assessment_tool": "nb:Assessment",
 }

--- a/bagel/mappings.py
+++ b/bagel/mappings.py
@@ -1,22 +1,30 @@
+from collections import namedtuple
+
+Namespace = namedtuple("Namespace", ["pf", "url"])
+NB = Namespace("nb", "http://neurobagel.org/vocab/")
+SNOMED = Namespace("snomed", "http://purl.bioontology.org/ontology/SNOMEDCT/")
+NIDM = Namespace("nidm", "http://purl.org/nidash/nidm#")
+COGATLAS = Namespace("cogatlas", "https://www.cognitiveatlas.org/task/id/")
+
 BIDS = {
-    "anat": "nidm:Anatomical",
-    "func": "nidm:Functional",
-    "dwi": "nidm:DiffusionWeighted",
-    "bval": "nidm:b-value",
-    "bvec": "nidm:b-vector",
-    "T1w": "nidm:T1Weighted",
-    "T2w": "nidm:T2Weighted",
-    "inplaneT2": "nidm:T2Weighted",
-    "bold": "nidm:FlowWeighted",
-    "dti": "nidm:DiffusionTensor",
-    "asl": "nidm:ArterialSpinLabeling",
+    "anat": NIDM.pf + ":Anatomical",
+    "func": NIDM.pf + ":Functional",
+    "dwi": NIDM.pf + ":DiffusionWeighted",
+    "bval": NIDM.pf + ":b-value",
+    "bvec": NIDM.pf + ":b-vector",
+    "T1w": NIDM.pf + ":T1Weighted",
+    "T2w": NIDM.pf + ":T2Weighted",
+    "inplaneT2": NIDM.pf + ":T2Weighted",
+    "bold": NIDM.pf + ":FlowWeighted",
+    "dti": NIDM.pf + ":DiffusionTensor",
+    "asl": NIDM.pf + ":ArterialSpinLabeling",
 }
 NEUROBAGEL = {
-    "participant": "nb:ParticipantID",  # TODO: Add to graph?
-    "session": "nb:SessionID",  # TODO: Add to graph?
-    "sex": "nb:Sex",
-    "age": "nb:Age",
-    "diagnosis": "nb:Diagnosis",
+    "participant": NB.pf + ":ParticipantID",
+    "session": NB.pf + ":SessionID",
+    "sex": NB.pf + ":Sex",
+    "age": NB.pf + ":Age",
+    "diagnosis": NB.pf + ":Diagnosis",
     "healthy_control": "purl:NCIT_C94342",
-    "assessment_tool": "nb:Assessment",
+    "assessment_tool": NB.pf + ":Assessment",
 }

--- a/bagel/models.py
+++ b/bagel/models.py
@@ -3,8 +3,10 @@ from typing import List, Literal, Optional, Union
 
 from pydantic import BaseModel, Extra, Field, HttpUrl
 
+from bagel.mappings import NB
+
 UUID_PATTERN = r"[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$"
-BAGEL_UUID_PATTERN = r"^nb:" + UUID_PATTERN
+BAGEL_UUID_PATTERN = rf"^{NB.pf}:{UUID_PATTERN}"
 
 
 class Bagel(BaseModel, extra=Extra.forbid):
@@ -13,7 +15,7 @@ class Bagel(BaseModel, extra=Extra.forbid):
 
     identifier: str = Field(
         regex=BAGEL_UUID_PATTERN,
-        default_factory=lambda: "nb:" + str(uuid.uuid4()),
+        default_factory=lambda: NB.pf + ":" + str(uuid.uuid4()),
     )
 
 

--- a/bagel/models.py
+++ b/bagel/models.py
@@ -4,16 +4,16 @@ from typing import List, Literal, Optional, Union
 from pydantic import BaseModel, Extra, Field, HttpUrl
 
 UUID_PATTERN = r"[0-9a-fA-F]{8}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{4}\b-[0-9a-fA-F]{12}$"
-BAGEL_UUID_PATTERN = r"^bg:" + UUID_PATTERN
+BAGEL_UUID_PATTERN = r"^nb:" + UUID_PATTERN
 
 
 class Bagel(BaseModel, extra=Extra.forbid):
-    """identifier has to be a valid UUID prepended by the bg: namespace
+    """identifier has to be a valid UUID prepended by the nb: namespace
     by default, a random (uuid4) string UUID will be created"""
 
     identifier: str = Field(
         regex=BAGEL_UUID_PATTERN,
-        default_factory=lambda: "bg:" + str(uuid.uuid4()),
+        default_factory=lambda: "nb:" + str(uuid.uuid4()),
     )
 
 
@@ -28,24 +28,24 @@ class Acquisition(Bagel):
 
 
 class Session(Bagel):
-    label: str
-    filePath: Optional[str] = None
+    hasLabel: str
+    hasFilePath: Optional[str] = None
     hasAcquisition: List[Acquisition]
     schemaKey: Literal["Session"] = "Session"
 
 
 class Subject(Bagel):
-    label: str
+    hasLabel: str
     hasSession: Optional[List[Session]] = None
-    age: Optional[float] = None
-    sex: Optional[ControlledTerm] = None
+    hasAge: Optional[float] = None
+    hasSex: Optional[ControlledTerm] = None
     isSubjectGroup: Optional[ControlledTerm] = None
-    diagnosis: Optional[List[ControlledTerm]] = None
-    assessment: Optional[List[ControlledTerm]] = None
+    hasDiagnosis: Optional[List[ControlledTerm]] = None
+    hasAssessment: Optional[List[ControlledTerm]] = None
     schemaKey: Literal["Subject"] = "Subject"
 
 
 class Dataset(Bagel):
-    label: str
+    hasLabel: str
     hasSamples: List[Subject]
     schemaKey: Literal["Dataset"] = "Dataset"

--- a/bagel/models.py
+++ b/bagel/models.py
@@ -10,7 +10,7 @@ BAGEL_UUID_PATTERN = rf"^{NB.pf}:{UUID_PATTERN}"
 
 
 class Bagel(BaseModel, extra=Extra.forbid):
-    """identifier has to be a valid UUID prepended by the nb: namespace
+    """identifier has to be a valid UUID prepended by the Neurobagel namespace
     by default, a random (uuid4) string UUID will be created"""
 
     identifier: str = Field(

--- a/bagel/tests/data/example1.json
+++ b/bagel/tests/data/example1.json
@@ -3,7 +3,7 @@
         "Description": "A participant ID",
         "Annotations": {
             "IsAbout": {
-                "TermURL": "bg:ParticipantID",
+                "TermURL": "nb:ParticipantID",
                 "Label": "Unique participant identifier"
             }
         }
@@ -12,7 +12,7 @@
         "Description": "A session ID",
         "Annotations": {
             "IsAbout": {
-                "TermURL": "bg:SessionID",
+                "TermURL": "nb:SessionID",
                 "Label": "Unique session identifier"
             }
         }
@@ -25,7 +25,7 @@
         },
         "Annotations": {
             "IsAbout": {
-                "TermURL": "bg:diagnosis",
+                "TermURL": "nb:Diagnosis",
                 "Label": "Diagnosis"
             },
             "Levels": {

--- a/bagel/tests/data/example10.json
+++ b/bagel/tests/data/example10.json
@@ -3,7 +3,7 @@
         "Description": "A participant ID",
         "Annotations": {
             "IsAbout": {
-                "TermURL": "bg:ParticipantID",
+                "TermURL": "nb:ParticipantID",
                 "Label": "Unique participant identifier"
             }
         }
@@ -12,7 +12,7 @@
         "Description": "A session ID",
         "Annotations": {
             "IsAbout": {
-                "TermURL": "bg:SessionID",
+                "TermURL": "nb:SessionID",
                 "Label": "Unique session identifier"
             }
         }
@@ -25,7 +25,7 @@
         },
         "Annotations": {
             "IsAbout": {
-                "TermURL": "bg:diagnosis",
+                "TermURL": "nb:Diagnosis",
                 "Label": "Diagnosis"
             },
             "Levels": {
@@ -45,11 +45,11 @@
         "Description": "item 1 scores for an imaginary tool",
         "Annotations": {
             "IsAbout": {
-                "TermURL": "bg:Assessment",
+                "TermURL": "nb:Assessment",
                 "Label": "Assessment tool"
             },
             "IsPartOf": {
-                "TermURL": "cogAtlas:1234",
+                "TermURL": "cogatlas:1234",
                 "Label": "Imaginary tool"
             },
             "MissingValues": ["missing", "NOT IN TSV 1", "NOT IN TSV 2"]
@@ -59,11 +59,11 @@
         "Description": "item 2 scores for an imaginary tool",
         "Annotations": {
             "IsAbout": {
-                "TermURL": "bg:Assessment",
+                "TermURL": "nb:Assessment",
                 "Label": "Assessment tool"
             },
             "IsPartOf": {
-                "TermURL": "cogAtlas:1234",
+                "TermURL": "cogatlas:1234",
                 "Label": "Imaginary tool"
             },
             "MissingValues": ["missing", "NOT IN TSV 1", "NOT IN TSV 2"]
@@ -73,11 +73,11 @@
         "Description": "item 1 scores for a different imaginary tool",
         "Annotations": {
             "IsAbout": {
-                "TermURL": "bg:Assessment",
+                "TermURL": "nb:Assessment",
                 "Label": "Assessment tool"
             },
             "IsPartOf": {
-                "TermURL": "cogAtlas:4321",
+                "TermURL": "cogatlas:4321",
                 "Label": "A different imaginary tool"
             },
             "MissingValues": ["none"]

--- a/bagel/tests/data/example11.json
+++ b/bagel/tests/data/example11.json
@@ -3,7 +3,7 @@
         "Description": "A participant ID",
         "Annotations": {
             "IsAbout": {
-                "TermURL": "bg:ParticipantID",
+                "TermURL": "nb:ParticipantID",
                 "Label": "Unique participant identifier"
             }
         }
@@ -12,7 +12,7 @@
         "Description": "A session ID",
         "Annotations": {
             "IsAbout": {
-                "TermURL": "bg:SessionID",
+                "TermURL": "nb:SessionID",
                 "Label": "Unique session identifier"
             }
         }
@@ -25,7 +25,7 @@
         },
         "Annotations": {
             "IsAbout": {
-                "TermURL": "bg:diagnosis",
+                "TermURL": "nb:Diagnosis",
                 "Label": "Diagnosis"
             },
             "Levels": {
@@ -45,11 +45,11 @@
         "Description": "item 1 scores for an imaginary tool",
         "Annotations": {
             "IsAbout": {
-                "TermURL": "bg:Assessment",
+                "TermURL": "nb:Assessment",
                 "Label": "Assessment tool"
             },
             "IsPartOf": {
-                "TermURL": "cogAtlas:1234",
+                "TermURL": "cogatlas:1234",
                 "Label": "Imaginary tool"
             },
             "MissingValues": ["missing"]
@@ -59,11 +59,11 @@
         "Description": "item 2 scores for an imaginary tool",
         "Annotations": {
             "IsAbout": {
-                "TermURL": "bg:Assessment",
+                "TermURL": "nb:Assessment",
                 "Label": "Assessment tool"
             },
             "IsPartOf": {
-                "TermURL": "cogAtlas:1234",
+                "TermURL": "cogatlas:1234",
                 "Label": "Imaginary tool"
             },
             "MissingValues": ["missing"]
@@ -73,11 +73,11 @@
         "Description": "item 1 scores for a different imaginary tool",
         "Annotations": {
             "IsAbout": {
-                "TermURL": "bg:Assessment",
+                "TermURL": "nb:Assessment",
                 "Label": "Assessment tool"
             },
             "IsPartOf": {
-                "TermURL": "cogAtlas:4321",
+                "TermURL": "cogatlas:4321",
                 "Label": "A different imaginary tool"
             },
             "MissingValues": ["none"]

--- a/bagel/tests/data/example2.json
+++ b/bagel/tests/data/example2.json
@@ -3,7 +3,7 @@
     "Description": "A participant ID",
     "Annotations": {
       "IsAbout": {
-        "TermURL": "bg:ParticipantID",
+        "TermURL": "nb:ParticipantID",
         "Label": "Unique participant identifier"
       }
     }
@@ -12,7 +12,7 @@
     "Description": "A session ID",
     "Annotations": {
       "IsAbout": {
-        "TermURL": "bg:SessionID",
+        "TermURL": "nb:SessionID",
         "Label": "Unique session identifier"
       }
     }
@@ -25,7 +25,7 @@
     },
     "Annotations": {
       "IsAbout": {
-        "TermURL": "bg:diagnosis",
+        "TermURL": "nb:Diagnosis",
         "Label": "Diagnosis"
       },
       "Levels": {
@@ -48,16 +48,16 @@
     },
     "Annotations": {
       "IsAbout": {
-        "TermURL": "bg:sex",
+        "TermURL": "nb:Sex",
         "Label": "Sex"
       },
       "Levels": {
         "M": {
-          "TermURL": "bids:Male",
+          "TermURL": "snomed:248153007",
           "Label": "Male"
         },
         "F": {
-          "TermURL": "bids:Female",
+          "TermURL": "snomed:248152002",
           "Label": "Female"
         }
       }
@@ -67,11 +67,11 @@
     "Description": "Age of the participant",
     "Annotations": {
       "IsAbout": {
-        "TermURL": "bg:Age",
+        "TermURL": "nb:Age",
         "Label": "Chronological age"
       },
       "Transformation": {
-        "TermURL": "bg:iso8601",
+        "TermURL": "nb:iso8601",
         "Label": "A period of time defined according to the ISO8601 standard"
       }
     }

--- a/bagel/tests/data/example4.json
+++ b/bagel/tests/data/example4.json
@@ -3,7 +3,7 @@
         "Description": "A participant ID",
         "Annotations": {
             "IsAbout": {
-                "TermURL": "bg:ParticipantID",
+                "TermURL": "nb:ParticipantID",
                 "Label": "Unique participant identifier"
             }
         }
@@ -12,7 +12,7 @@
         "Description": "A session ID",
         "Annotations": {
             "IsAbout": {
-                "TermURL": "bg:SessionID",
+                "TermURL": "nb:SessionID",
                 "Label": "Unique session identifier"
             }
         }
@@ -25,7 +25,7 @@
         },
         "Annotations": {
             "IsAbout": {
-                "TermURL": "bg:diagnosis",
+                "TermURL": "nb:Diagnosis",
                 "Label": "Diagnosis"
             },
             "Levels": {

--- a/bagel/tests/data/example5.json
+++ b/bagel/tests/data/example5.json
@@ -3,7 +3,7 @@
         "Description": "A participant ID",
         "Annotations": {
             "IsAbout": {
-                "TermURL": "bg:ParticipantID",
+                "TermURL": "nb:ParticipantID",
                 "Label": "Unique participant identifier"
             }
         }
@@ -12,7 +12,7 @@
         "Description": "A session ID",
         "Annotations": {
             "IsAbout": {
-                "TermURL": "bg:SessionID",
+                "TermURL": "nb:SessionID",
                 "Label": "Unique session identifier"
             }
         }
@@ -25,7 +25,7 @@
         },
         "Annotations": {
             "IsAbout": {
-                "TermURL": "bg:diagnosis",
+                "TermURL": "nb:Diagnosis",
                 "Label": "Diagnosis"
             },
             "Levels": {

--- a/bagel/tests/data/example6.json
+++ b/bagel/tests/data/example6.json
@@ -3,7 +3,7 @@
         "Description": "A participant ID",
         "Annotations": {
             "IsAbout": {
-                "TermURL": "bg:ParticipantID",
+                "TermURL": "nb:ParticipantID",
                 "Label": "Unique participant identifier"
             }
         }
@@ -12,7 +12,7 @@
         "Description": "A session ID",
         "Annotations": {
             "IsAbout": {
-                "TermURL": "bg:SessionID",
+                "TermURL": "nb:SessionID",
                 "Label": "Unique session identifier"
             }
         }
@@ -25,7 +25,7 @@
         },
         "Annotations": {
             "IsAbout": {
-                "TermURL": "bg:diagnosis",
+                "TermURL": "nb:Diagnosis",
                 "Label": "Diagnosis"
             },
             "Levels": {
@@ -45,11 +45,11 @@
         "Description": "item 1 scores for an imaginary tool",
         "Annotations": {
             "IsAbout": {
-                "TermURL": "bg:Assessment",
+                "TermURL": "nb:Assessment",
                 "Label": "Assessment tool"
             },
             "IsPartOf": {
-                "TermURL": "cogAtlas:1234",
+                "TermURL": "cogatlas:1234",
                 "Label": "Imaginary tool"
             },
             "MissingValues": ["missing"]
@@ -59,11 +59,11 @@
         "Description": "item 2 scores for an imaginary tool",
         "Annotations": {
             "IsAbout": {
-                "TermURL": "bg:Assessment",
+                "TermURL": "nb:Assessment",
                 "Label": "Assessment tool"
             },
             "IsPartOf": {
-                "TermURL": "cogAtlas:1234",
+                "TermURL": "cogatlas:1234",
                 "Label": "Imaginary tool"
             },
             "MissingValues": ["missing"]
@@ -73,11 +73,11 @@
         "Description": "item 1 scores for a different imaginary tool",
         "Annotations": {
             "IsAbout": {
-                "TermURL": "bg:Assessment",
+                "TermURL": "nb:Assessment",
                 "Label": "Assessment tool"
             },
             "IsPartOf": {
-                "TermURL": "cogAtlas:4321",
+                "TermURL": "cogatlas:4321",
                 "Label": "A different imaginary tool"
             },
             "MissingValues": ["none"]

--- a/bagel/tests/data/example7.json
+++ b/bagel/tests/data/example7.json
@@ -3,7 +3,7 @@
         "Description": "A participant ID",
         "Annotations": {
             "IsAbout": {
-                "TermURL": "bg:ParticipantID",
+                "TermURL": "nb:ParticipantID",
                 "Label": "Unique participant identifier"
             }
         }
@@ -12,7 +12,7 @@
         "Description": "A session ID",
         "Annotations": {
             "IsAbout": {
-                "TermURL": "bg:SessionID",
+                "TermURL": "nb:SessionID",
                 "Label": "Unique session identifier"
             }
         }
@@ -25,7 +25,7 @@
         },
         "Annotations": {
             "IsAbout": {
-                "TermURL": "bg:diagnosis",
+                "TermURL": "nb:Diagnosis",
                 "Label": "Diagnosis"
             },
             "Levels": {

--- a/bagel/tests/data/example8.json
+++ b/bagel/tests/data/example8.json
@@ -3,7 +3,7 @@
         "Description": "A participant ID",
         "Annotations": {
             "IsAbout": {
-                "TermURL": "bg:ParticipantID",
+                "TermURL": "nb:ParticipantID",
                 "Label": "Unique participant identifier"
             }
         }
@@ -12,7 +12,7 @@
         "Description": "A participant ID",
         "Annotations": {
             "IsAbout": {
-                "TermURL": "bg:ParticipantID",
+                "TermURL": "nb:ParticipantID",
                 "Label": "Unique participant identifier"
             }
         }
@@ -21,7 +21,7 @@
         "Description": "A session ID",
         "Annotations": {
             "IsAbout": {
-                "TermURL": "bg:SessionID",
+                "TermURL": "nb:SessionID",
                 "Label": "Unique session identifier"
             }
         }
@@ -34,7 +34,7 @@
         },
         "Annotations": {
             "IsAbout": {
-                "TermURL": "bg:diagnosis",
+                "TermURL": "nb:Diagnosis",
                 "Label": "Diagnosis"
             },
             "Levels": {

--- a/bagel/tests/data/example9.json
+++ b/bagel/tests/data/example9.json
@@ -3,7 +3,7 @@
         "Description": "A participant ID",
         "Annotations": {
             "IsAbout": {
-                "TermURL": "bg:ParticipantID",
+                "TermURL": "nb:ParticipantID",
                 "Label": "Unique participant identifier"
             }
         }
@@ -12,7 +12,7 @@
         "Description": "A session ID",
         "Annotations": {
             "IsAbout": {
-                "TermURL": "bg:SessionID",
+                "TermURL": "nb:SessionID",
                 "Label": "Unique session identifier"
             }
         }
@@ -25,7 +25,7 @@
         },
         "Annotations": {
             "IsAbout": {
-                "TermURL": "bg:diagnosis",
+                "TermURL": "nb:Diagnosis",
                 "Label": "Diagnosis"
             },
             "Levels": {
@@ -45,11 +45,11 @@
         "Description": "item 1 scores for an imaginary tool",
         "Annotations": {
             "IsAbout": {
-                "TermURL": "bg:Assessment",
+                "TermURL": "nb:Assessment",
                 "Label": "Assessment tool"
             },
             "IsPartOf": {
-                "TermURL": "cogAtlas:1234",
+                "TermURL": "cogatlas:1234",
                 "Label": "Imaginary tool"
             },
             "MissingValues": ["missing"]
@@ -59,11 +59,11 @@
         "Description": "item 2 scores for an imaginary tool",
         "Annotations": {
             "IsAbout": {
-                "TermURL": "bg:Assessment",
+                "TermURL": "nb:Assessment",
                 "Label": "Assessment tool"
             },
             "IsPartOf": {
-                "TermURL": "cogAtlas:1234",
+                "TermURL": "cogatlas:1234",
                 "Label": "Imaginary tool"
             },
             "MissingValues": ["missing"]
@@ -73,11 +73,11 @@
         "Description": "item 1 scores for a different imaginary tool",
         "Annotations": {
             "IsAbout": {
-                "TermURL": "bg:Assessment",
+                "TermURL": "nb:Assessment",
                 "Label": "Assessment tool"
             },
             "IsPartOf": {
-                "TermURL": "cogAtlas:4321",
+                "TermURL": "cogatlas:4321",
                 "Label": "A different imaginary tool"
             },
             "MissingValues": ["none"]

--- a/bagel/tests/data/example_synthetic.json
+++ b/bagel/tests/data/example_synthetic.json
@@ -3,7 +3,7 @@
         "Description": "A participant ID",
         "Annotations": {
             "IsAbout": {
-                "TermURL": "bg:ParticipantID",
+                "TermURL": "nb:ParticipantID",
                 "Label": "Unique participant identifier"
             }
         }
@@ -12,7 +12,7 @@
         "Description": "A session ID",
         "Annotations": {
             "IsAbout": {
-                "TermURL": "bg:SessionID",
+                "TermURL": "nb:SessionID",
                 "Label": "Unique session identifier"
             }
         }
@@ -21,11 +21,11 @@
     "Description": "Age of the participant",
     "Annotations": {
       "IsAbout": {
-        "TermURL": "bg:Age",
+        "TermURL": "nb:Age",
         "Label": "Chronological age"
       },
       "Transformation": {
-        "TermURL": "bg:euro",
+        "TermURL": "nb:euro",
         "Label": "writing the time with a comma - why not"
       }
     }
@@ -38,16 +38,16 @@
     },
     "Annotations": {
       "IsAbout": {
-        "TermURL": "bg:sex",
+        "TermURL": "nb:Sex",
         "Label": "Sex"
       },
       "Levels": {
         "M": {
-          "TermURL": "bids:Male",
+          "TermURL": "snomed:248153007",
           "Label": "Male"
         },
         "F": {
-          "TermURL": "bids:Female",
+          "TermURL": "snomed:248152002",
           "Label": "Female"
         }
       }
@@ -62,7 +62,7 @@
         },
         "Annotations": {
             "IsAbout": {
-                "TermURL": "bg:diagnosis",
+                "TermURL": "nb:Diagnosis",
                 "Label": "Diagnosis"
             },
             "Levels": {
@@ -81,11 +81,11 @@
         "Description": "item 1 scores for tool1",
         "Annotations": {
             "IsAbout": {
-                "TermURL": "bg:Assessment",
+                "TermURL": "nb:Assessment",
                 "Label": "Assessment tool"
             },
             "IsPartOf": {
-                "TermURL": "cogAtlas:1234",
+                "TermURL": "cogatlas:1234",
                 "Label": "Imaginary tool"
             },
             "MissingValues": ["missing"]
@@ -95,11 +95,11 @@
         "Description": "item 2 scores for tool1",
         "Annotations": {
             "IsAbout": {
-                "TermURL": "bg:Assessment",
+                "TermURL": "nb:Assessment",
                 "Label": "Assessment tool"
             },
             "IsPartOf": {
-                "TermURL": "cogAtlas:1234",
+                "TermURL": "cogatlas:1234",
                 "Label": "Imaginary tool"
             },
             "MissingValues": ["missing"]
@@ -109,11 +109,11 @@
         "Description": "item 1 scores for tool2",
         "Annotations": {
             "IsAbout": {
-                "TermURL": "bg:Assessment",
+                "TermURL": "nb:Assessment",
                 "Label": "Assessment tool"
             },
             "IsPartOf": {
-                "TermURL": "cogAtlas:4321",
+                "TermURL": "cogatlas:4321",
                 "Label": "A different imaginary tool"
             },
             "MissingValues": ["not completed"]

--- a/bagel/tests/data/example_synthetic.jsonld
+++ b/bagel/tests/data/example_synthetic.jsonld
@@ -1,163 +1,163 @@
 {
   "@context": {
     "bg": "http://neurobagel.org/vocab/",
-    "snomed": "https://identifiers.org/snomedct:",
+    "snomed": "http://purl.bioontology.org/ontology/SNOMEDCT/",
     "nidm": "http://purl.org/nidash/nidm#",
-    "cogAtlas": "https://www.cognitiveatlas.org/task/id/",
-    "Acquisition": "bg:Acquisition",
+    "cogatlas": "https://www.cognitiveatlas.org/task/id/",
+    "Acquisition": "nb:Acquisition",
     "identifier": "@id",
     "hasContrastType": {
-      "@id": "bg:hasContrastType"
+      "@id": "nb:hasContrastType"
     },
     "schemaKey": "@type",
-    "Bagel": "bg:Bagel",
-    "BaseModel": "bg:BaseModel",
-    "ControlledTerm": "bg:ControlledTerm",
-    "Dataset": "bg:Dataset",
-    "label": {
-      "@id": "bg:label"
+    "Bagel": "nb:Bagel",
+    "BaseModel": "nb:BaseModel",
+    "ControlledTerm": "nb:ControlledTerm",
+    "Dataset": "nb:Dataset",
+    "hasLabel": {
+      "@id": "nb:hasLabel"
     },
     "hasSamples": {
-      "@id": "bg:hasSamples"
+      "@id": "nb:hasSamples"
     },
-    "Image": "bg:Image",
-    "Session": "bg:Session",
-    "filePath": {
-      "@id": "bg:filePath"
+    "Image": "nb:Image",
+    "Session": "nb:Session",
+    "hasFilePath": {
+      "@id": "nb:hasFilePath"
     },
     "hasAcquisition": {
-      "@id": "bg:hasAcquisition"
+      "@id": "nb:hasAcquisition"
     },
-    "Subject": "bg:Subject",
+    "Subject": "nb:Subject",
     "hasSession": {
-      "@id": "bg:hasSession"
+      "@id": "nb:hasSession"
     },
-    "age": {
-      "@id": "bg:age"
+    "hasAge": {
+      "@id": "nb:hasAge"
     },
-    "sex": {
-      "@id": "bg:sex"
+    "hasSex": {
+      "@id": "nb:hasSex"
     },
     "isSubjectGroup": {
-      "@id": "bg:isSubjectGroup"
+      "@id": "nb:isSubjectGroup"
     },
-    "diagnosis": {
-      "@id": "bg:diagnosis"
+    "hasDiagnosis": {
+      "@id": "nb:hasDiagnosis"
     },
-    "assessment": {
-      "@id": "bg:assessment"
+    "hasAssessment": {
+      "@id": "nb:hasAssessment"
     }
   },
-  "identifier": "bg:d6da97be-3788-4865-824c-5bfd0dd09ebe",
-  "label": "BIDS synthetic",
+  "identifier": "nb:d6da97be-3788-4865-824c-5bfd0dd09ebe",
+  "hasLabel": "BIDS synthetic",
   "hasSamples": [
     {
-      "identifier": "bg:a63aaaed-5abe-494c-8ad5-8cb84f44cf72",
-      "label": "sub-01",
-      "age": 34.1,
-      "sex": {
-        "identifier": "bids:Female",
+      "identifier": "nb:a63aaaed-5abe-494c-8ad5-8cb84f44cf72",
+      "hasLabel": "sub-01",
+      "hasAge": 34.1,
+      "hasSex": {
+        "identifier": "snomed:248152002",
         "schemaKey": "Sex"
       },
       "isSubjectGroup": {
         "identifier": "purl:NCIT_C94342",
         "schemaKey": "SubjectGroup"
       },
-      "assessment": [
+      "hasAssessment": [
         {
-          "identifier": "cogAtlas:1234",
+          "identifier": "cogatlas:1234",
           "schemaKey": "Assessment"
         },
         {
-          "identifier": "cogAtlas:4321",
+          "identifier": "cogatlas:4321",
           "schemaKey": "Assessment"
         }
       ],
       "schemaKey": "Subject"
     },
     {
-      "identifier": "bg:57a0edd2-bbed-471e-8f67-0dca88ed58e5",
-      "label": "sub-02",
-      "age": 38.1,
-      "sex": {
-        "identifier": "bids:Male",
+      "identifier": "nb:57a0edd2-bbed-471e-8f67-0dca88ed58e5",
+      "hasLabel": "sub-02",
+      "hasAge": 38.1,
+      "hasSex": {
+        "identifier": "snomed:248153007",
         "schemaKey": "Sex"
       },
-      "diagnosis": [
+      "hasDiagnosis": [
         {
           "identifier": "snomed:49049000",
           "schemaKey": "Diagnosis"
         }
       ],
-      "assessment": [
+      "hasAssessment": [
         {
-          "identifier": "cogAtlas:4321",
+          "identifier": "cogatlas:4321",
           "schemaKey": "Assessment"
         }
       ],
       "schemaKey": "Subject"
     },
     {
-      "identifier": "bg:5e5bbec0-4625-480d-9aaf-0471b242b9d9",
-      "label": "sub-03",
-      "age": 22.1,
-      "sex": {
-        "identifier": "bids:Male",
+      "identifier": "nb:5e5bbec0-4625-480d-9aaf-0471b242b9d9",
+      "hasLabel": "sub-03",
+      "hasAge": 22.1,
+      "hasSex": {
+        "identifier": "snomed:248153007",
         "schemaKey": "Sex"
       },
       "isSubjectGroup": {
         "identifier": "purl:NCIT_C94342",
         "schemaKey": "SubjectGroup"
       },
-      "assessment": [
+      "hasAssessment": [
         {
-          "identifier": "cogAtlas:1234",
+          "identifier": "cogatlas:1234",
           "schemaKey": "Assessment"
         }
       ],
       "schemaKey": "Subject"
     },
     {
-      "identifier": "bg:b595fe1c-7202-48a9-80a4-d1b59cc2cb17",
-      "label": "sub-04",
-      "age": 21.1,
-      "sex": {
-        "identifier": "bids:Female",
+      "identifier": "nb:b595fe1c-7202-48a9-80a4-d1b59cc2cb17",
+      "hasLabel": "sub-04",
+      "hasAge": 21.1,
+      "hasSex": {
+        "identifier": "snomed:248152002",
         "schemaKey": "Sex"
       },
       "isSubjectGroup": {
         "identifier": "purl:NCIT_C94342",
         "schemaKey": "SubjectGroup"
       },
-      "assessment": [
+      "hasAssessment": [
         {
-          "identifier": "cogAtlas:4321",
+          "identifier": "cogatlas:4321",
           "schemaKey": "Assessment"
         }
       ],
       "schemaKey": "Subject"
     },
     {
-      "identifier": "bg:d5e885b0-98e9-461e-be7c-3e9b8d093984",
-      "label": "sub-05",
-      "age": 42.5,
-      "sex": {
-        "identifier": "bids:Male",
+      "identifier": "nb:d5e885b0-98e9-461e-be7c-3e9b8d093984",
+      "hasLabel": "sub-05",
+      "hasAge": 42.5,
+      "hasSex": {
+        "identifier": "snomed:248153007",
         "schemaKey": "Sex"
       },
-      "diagnosis": [
+      "hasDiagnosis": [
         {
           "identifier": "snomed:49049000",
           "schemaKey": "Diagnosis"
         }
       ],
-      "assessment": [
+      "hasAssessment": [
         {
-          "identifier": "cogAtlas:1234",
+          "identifier": "cogatlas:1234",
           "schemaKey": "Assessment"
         },
         {
-          "identifier": "cogAtlas:4321",
+          "identifier": "cogatlas:4321",
           "schemaKey": "Assessment"
         }
       ],

--- a/bagel/tests/test_cli_bids.py
+++ b/bagel/tests/test_cli_bids.py
@@ -49,7 +49,7 @@ def test_bids_sessions_have_correct_labels(
     pheno_bids = load_test_json(tmp_path / "pheno_bids.jsonld")
     for sub in pheno_bids["hasSamples"]:
         assert ["ses-01", "ses-02"] == [
-            ses["label"] for ses in sub["hasSession"]
+            ses["hasLabel"] for ses in sub["hasSession"]
         ]
 
 
@@ -79,7 +79,7 @@ def test_bids_data_with_sessions_have_correct_paths(
     pheno_bids = load_test_json(tmp_path / "pheno_bids.jsonld")
     for sub in pheno_bids["hasSamples"]:
         for ses in sub["hasSession"]:
-            assert sub["label"] in ses["filePath"]
-            assert ses["label"] in ses["filePath"]
-            assert Path(ses["filePath"]).is_absolute()
-            assert Path(ses["filePath"]).is_dir()
+            assert sub["hasLabel"] in ses["hasFilePath"]
+            assert ses["hasLabel"] in ses["hasFilePath"]
+            assert Path(ses["hasFilePath"]).is_absolute()
+            assert Path(ses["hasFilePath"]).is_dir()

--- a/bagel/tests/test_cli_pheno.py
+++ b/bagel/tests/test_cli_pheno.py
@@ -49,7 +49,11 @@ def test_pheno_valid_inputs_run_successfully(
                 "'group': ['UNANNOTATED']",
             ],
         ),
-        ("example11", LookupError, ["missing values in participant or session id"])
+        (
+            "example11",
+            LookupError,
+            ["missing values in participant or session id"],
+        ),
     ],
 )
 def test_invalid_inputs_are_handled_gracefully(
@@ -133,7 +137,7 @@ def test_that_output_file_contains_name(
 
     pheno = load_test_json(tmp_path / "pheno.jsonld")
 
-    assert pheno.get("label") == "my_dataset_name"
+    assert pheno.get("hasLabel") == "my_dataset_name"
 
 
 def test_diagnosis_and_control_status_handled(
@@ -157,11 +161,11 @@ def test_diagnosis_and_control_status_handled(
     pheno = load_test_json(tmp_path / "pheno.jsonld")
 
     assert (
-        pheno["hasSamples"][0]["diagnosis"][0]["identifier"]
+        pheno["hasSamples"][0]["hasDiagnosis"][0]["identifier"]
         == "snomed:49049000"
     )
-    assert "diagnosis" not in pheno["hasSamples"][1].keys()
-    assert "diagnosis" not in pheno["hasSamples"][2].keys()
+    assert "hasDiagnosis" not in pheno["hasSamples"][1].keys()
+    assert "hasDiagnosis" not in pheno["hasSamples"][2].keys()
     assert (
         pheno["hasSamples"][2]["isSubjectGroup"]["identifier"]
         == "purl:NCIT_C94342"
@@ -169,7 +173,7 @@ def test_diagnosis_and_control_status_handled(
 
 
 @pytest.mark.parametrize(
-    "attribute", ["sex", "diagnosis", "assessment", "isSubjectGroup"]
+    "attribute", ["hasSex", "hasDiagnosis", "hasAssessment", "isSubjectGroup"]
 )
 def test_controlled_terms_have_identifiers(
     attribute, runner, test_data, tmp_path, load_test_json
@@ -208,8 +212,8 @@ def test_controlled_terms_have_identifiers(
         (None, 1),
         (
             [
-                {"identifier": "cogAtlas:1234", "schemaKey": "Assessment"},
-                {"identifier": "cogAtlas:4321", "schemaKey": "Assessment"},
+                {"identifier": "cogatlas:1234", "schemaKey": "Assessment"},
+                {"identifier": "cogatlas:4321", "schemaKey": "Assessment"},
             ],
             2,
         ),
@@ -235,7 +239,7 @@ def test_assessment_data_are_parsed_correctly(
 
     pheno = load_test_json(tmp_path / "pheno.jsonld")
 
-    assert assessment == pheno["hasSamples"][subject].get("assessment")
+    assert assessment == pheno["hasSamples"][subject].get("hasAssessment")
 
 
 @pytest.mark.parametrize(
@@ -262,7 +266,7 @@ def test_cli_age_is_processed(
 
     pheno = load_test_json(tmp_path / "pheno.jsonld")
 
-    assert expected_age == pheno["hasSamples"][subject]["age"]
+    assert expected_age == pheno["hasSamples"][subject]["hasAge"]
 
 
 def test_output_includes_context(runner, test_data, tmp_path, load_test_json):


### PR DESCRIPTION
- Controlled terms and model class attributes (properties) have been renamed according to https://github.com/neurobagel/encarta/blob/main/docs/standards.md. Tests and example files have also been updated.
- Used namespaces are now stored in `namedtuples` and prefixes accessed through the corresponding field
- New constant created to store labels and URIs of age heuristics

Closes #124, closes #89, closes #125