### PR TITLE
[INFRA] add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# Documentation
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+
+  - package-ecosystem: 'gitsubmodule'
+    directory: '/'
+    schedule:
+      interval: 'weekly'


### PR DESCRIPTION
relates to https://github.com/neurobagel/project/issues/73

## Changes made

- adds dependabot to update github action versions and sub-modules on a weekly basis

Dependabot can also take of many other things (pip and npm dependencies) but I have never used those and I'd be more cautious about updating those as regularly as those used purely for infrastructure.

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file

Note that for this to work some things may need to be changed in the secutiry panel of the repo.

To give you an idea of the changes this would make I merged this PR in the main of my fork there are the PR that dependabot opened:

https://github.com/Remi-Gau/bagel-cli/pulls