### PR TITLE
[FIX] Reimplement controlled term classes

### DIFF
--- a/bagel/bids_utils.py
+++ b/bagel/bids_utils.py
@@ -42,7 +42,7 @@ def create_acquisitions(
         if mapped_term:
             image_list.append(
                 models.Acquisition(
-                    hasContrastType=models.ControlledTerm(identifier=mapped_term, schemaKey="Image")
+                    hasContrastType=models.Image(identifier=mapped_term)
                 )
             )
 

--- a/bagel/cli.py
+++ b/bagel/cli.py
@@ -77,11 +77,10 @@ def pheno(
 
         subject = models.Subject(hasLabel=str(participant))
         if "sex" in column_mapping.keys():
-            subject.hasSex = models.ControlledTerm(
+            subject.hasSex = models.Sex(
                 identifier=putil.get_transformed_values(
                     column_mapping["sex"], _sub_pheno, data_dictionary
                 ),
-                schemaKey="Sex",
             )
 
         if "diagnosis" in column_mapping.keys():
@@ -91,16 +90,11 @@ def pheno(
             if _dx_val is None:
                 pass
             elif _dx_val == mappings.NEUROBAGEL["healthy_control"]:
-                subject.isSubjectGroup = models.ControlledTerm(
+                subject.isSubjectGroup = models.SubjectGroup(
                     identifier=mappings.NEUROBAGEL["healthy_control"],
-                    schemaKey="SubjectGroup",
                 )
             else:
-                subject.hasDiagnosis = [
-                    models.ControlledTerm(
-                        identifier=_dx_val, schemaKey="Diagnosis"
-                    )
-                ]
+                subject.hasDiagnosis = [models.Diagnosis(identifier=_dx_val)]
 
         if "age" in column_mapping.keys():
             subject.hasAge = putil.get_transformed_values(
@@ -109,7 +103,7 @@ def pheno(
 
         if tool_mapping:
             _assessments = [
-                models.ControlledTerm(identifier=tool, schemaKey="Assessment")
+                models.Assessment(identifier=tool)
                 for tool, columns in tool_mapping.items()
                 if putil.are_not_missing(columns, _sub_pheno, data_dictionary)
             ]
@@ -156,7 +150,7 @@ def bids(
 ):
     """
     Extract imaging metadata from a valid BIDS dataset and combine them
-    with phenotypic metadata (.jsonld) created in a previous step using the 
+    with phenotypic metadata (.jsonld) created in a previous step using the
     bagel pheno command.
 
     This tool will create a valid, subject-level instance of the Neurobagel

--- a/bagel/models.py
+++ b/bagel/models.py
@@ -24,8 +24,28 @@ class ControlledTerm(BaseModel):
     schemaKey: str
 
 
+class Sex(ControlledTerm):
+    schemaKey = "Sex"
+
+
+class Diagnosis(ControlledTerm):
+    schemaKey = "Diagnosis"
+
+
+class SubjectGroup(ControlledTerm):
+    schemaKey = "SubjectGroup"
+
+
+class Assessment(ControlledTerm):
+    schemaKey = "Assessment"
+
+
+class Image(ControlledTerm):
+    schemaKey = "Image"
+
+
 class Acquisition(Bagel):
-    hasContrastType: ControlledTerm
+    hasContrastType: Image
     schemaKey: Literal["Acquisition"] = "Acquisition"
 
 
@@ -40,10 +60,10 @@ class Subject(Bagel):
     hasLabel: str
     hasSession: Optional[List[Session]] = None
     hasAge: Optional[float] = None
-    hasSex: Optional[ControlledTerm] = None
-    isSubjectGroup: Optional[ControlledTerm] = None
-    hasDiagnosis: Optional[List[ControlledTerm]] = None
-    hasAssessment: Optional[List[ControlledTerm]] = None
+    hasSex: Optional[Sex] = None
+    isSubjectGroup: Optional[SubjectGroup] = None
+    hasDiagnosis: Optional[List[Diagnosis]] = None
+    hasAssessment: Optional[List[Assessment]] = None
     schemaKey: Literal["Subject"] = "Subject"
 
 

--- a/bagel/pheno_utils.py
+++ b/bagel/pheno_utils.py
@@ -17,7 +17,6 @@ AGE_HEURISTICS = {
     "int": NB.pf + ":int",
     "euro": NB.pf + ":euro",
     "bounded": NB.pf + ":bounded",
-    "range": NB.pf + ":range",
     "iso8601": NB.pf + ":iso8601",
 }
 
@@ -132,9 +131,6 @@ def transform_age(value: str, heuristic: str) -> float:
             return float(value.replace(",", "."))
         if heuristic == AGE_HEURISTICS["bounded"]:
             return float(value.strip("+"))
-        if heuristic == AGE_HEURISTICS["range"]:
-            a_min, a_max = value.split("-")
-            return (float(a_min) + float(a_max)) / 2
         if heuristic == AGE_HEURISTICS["iso8601"]:
             if not value.startswith("P"):
                 value = "P" + value

--- a/bagel/tests/data/example_synthetic.jsonld
+++ b/bagel/tests/data/example_synthetic.jsonld
@@ -1,6 +1,6 @@
 {
   "@context": {
-    "bg": "http://neurobagel.org/vocab/",
+    "nb": "http://neurobagel.org/vocab/",
     "snomed": "http://purl.bioontology.org/ontology/SNOMEDCT/",
     "nidm": "http://purl.org/nidash/nidm#",
     "cogatlas": "https://www.cognitiveatlas.org/task/id/",
@@ -10,6 +10,7 @@
       "@id": "nb:hasContrastType"
     },
     "schemaKey": "@type",
+    "Assessment": "nb:Assessment",
     "Bagel": "nb:Bagel",
     "BaseModel": "nb:BaseModel",
     "ControlledTerm": "nb:ControlledTerm",
@@ -20,6 +21,7 @@
     "hasSamples": {
       "@id": "nb:hasSamples"
     },
+    "Diagnosis": "nb:Diagnosis",
     "Image": "nb:Image",
     "Session": "nb:Session",
     "hasFilePath": {
@@ -28,6 +30,7 @@
     "hasAcquisition": {
       "@id": "nb:hasAcquisition"
     },
+    "Sex": "nb:Sex",
     "Subject": "nb:Subject",
     "hasSession": {
       "@id": "nb:hasSession"
@@ -46,13 +49,14 @@
     },
     "hasAssessment": {
       "@id": "nb:hasAssessment"
-    }
+    },
+    "SubjectGroup": "nb:SubjectGroup"
   },
-  "identifier": "nb:d6da97be-3788-4865-824c-5bfd0dd09ebe",
+  "identifier": "nb:afa66724-2e1c-41e8-9d46-ca157aa70e5a",
   "hasLabel": "BIDS synthetic",
   "hasSamples": [
     {
-      "identifier": "nb:a63aaaed-5abe-494c-8ad5-8cb84f44cf72",
+      "identifier": "nb:4702ca14-aa5e-49e7-a0e4-1b8289f997f6",
       "hasLabel": "sub-01",
       "hasAge": 34.1,
       "hasSex": {
@@ -76,7 +80,7 @@
       "schemaKey": "Subject"
     },
     {
-      "identifier": "nb:57a0edd2-bbed-471e-8f67-0dca88ed58e5",
+      "identifier": "nb:8d7c57c6-f14e-4692-8ea1-9dcb199dffcd",
       "hasLabel": "sub-02",
       "hasAge": 38.1,
       "hasSex": {
@@ -98,7 +102,7 @@
       "schemaKey": "Subject"
     },
     {
-      "identifier": "nb:5e5bbec0-4625-480d-9aaf-0471b242b9d9",
+      "identifier": "nb:2d936fdb-0837-4748-9d5f-704ddcaab2ca",
       "hasLabel": "sub-03",
       "hasAge": 22.1,
       "hasSex": {
@@ -118,7 +122,7 @@
       "schemaKey": "Subject"
     },
     {
-      "identifier": "nb:b595fe1c-7202-48a9-80a4-d1b59cc2cb17",
+      "identifier": "nb:4d816d19-6dd0-499c-b55d-c07e1f37c6a2",
       "hasLabel": "sub-04",
       "hasAge": 21.1,
       "hasSex": {
@@ -138,7 +142,7 @@
       "schemaKey": "Subject"
     },
     {
-      "identifier": "nb:d5e885b0-98e9-461e-be7c-3e9b8d093984",
+      "identifier": "nb:db2b55b5-96b5-45d4-83fd-ec3b9e46db6b",
       "hasLabel": "sub-05",
       "hasAge": 42.5,
       "hasSex": {

--- a/bagel/tests/test_cli_pheno.py
+++ b/bagel/tests/test_cli_pheno.py
@@ -224,16 +224,20 @@ def test_controlled_term_classes_have_uri_type(
         ],
     )
 
-    pheno = load_test_json(tmp_path / "pheno.jsonld")
+    pheno = load_test_json(
+        test_data / "example_synthetic.jsonld"
+    )  # tmp_path / "pheno.jsonld"
 
     for sub in pheno["hasSamples"]:
         for key, value in sub.items():
-            if isinstance(value, (list, dict)):
-                if not isinstance(value, list):
-                    value = [value]
-                assert all(
-                    entry["schemaKey"] in pheno["@context"] for entry in value
-                ), f"Attribute {key} for subject {sub} has a schemaKey that does not have a corresponding URI in the context."
+            if not isinstance(value, (list, dict)):
+                continue
+            if isinstance(value, dict):
+                value = [value]
+            assert all(
+                entry.get("schemaKey", "no schemaKey set") in pheno["@context"]
+                for entry in value
+            ), f"Attribute {key} for subject {sub} has a schemaKey that does not have a corresponding URI in the context."
 
 
 @pytest.mark.parametrize(

--- a/bagel/tests/test_cli_pheno.py
+++ b/bagel/tests/test_cli_pheno.py
@@ -205,6 +205,37 @@ def test_controlled_terms_have_identifiers(
             ), f"{attribute}: did not have an identifier for subject {sub} and value {value}"
 
 
+def test_controlled_term_classes_have_uri_type(
+    runner, test_data, tmp_path, load_test_json
+):
+    """Tests that classes specified as schemaKeys (@type) for subject-level attributes in a .jsonld are also defined in the context."""
+    runner.invoke(
+        bagel,
+        [
+            "pheno",
+            "--pheno",
+            test_data / "example_synthetic.tsv",
+            "--dictionary",
+            test_data / "example_synthetic.json",
+            "--output",
+            tmp_path,
+            "--name",
+            "do not care name",
+        ],
+    )
+
+    pheno = load_test_json(tmp_path / "pheno.jsonld")
+
+    for sub in pheno["hasSamples"]:
+        for key, value in sub.items():
+            if isinstance(value, (list, dict)):
+                if not isinstance(value, list):
+                    value = [value]
+                assert all(
+                    entry["schemaKey"] in pheno["@context"] for entry in value
+                ), f"Attribute {key} for subject {sub} has a schemaKey that does not have a corresponding URI in the context."
+
+
 @pytest.mark.parametrize(
     "assessment, subject",
     [

--- a/bagel/tests/test_utility.py
+++ b/bagel/tests/test_utility.py
@@ -174,6 +174,11 @@ def test_invalid_age_heuristic():
     "model, attributes",
     [
         ("Bagel", ["identifier"]),
+        ("Sex", ["identifier", "schemaKey"]),
+        ("Diagnosis", ["identifier", "schemaKey"]),
+        ("SubjectGroup", ["identifier", "schemaKey"]),
+        ("Assessment", ["identifier", "schemaKey"]),
+        ("Image", ["identifier", "schemaKey"]),
         ("Acquisition", ["hasContrastType", "schemaKey"]),
         (
             "Session",

--- a/bagel/tests/test_utility.py
+++ b/bagel/tests/test_utility.py
@@ -132,7 +132,6 @@ def test_missing_ids_in_columns(test_data, columns, expected_indices):
         ("11", 11.0, "nb:int"),
         ("11,0", 11.0, "nb:euro"),
         ("90+", 90.0, "nb:bounded"),
-        ("20-30", 25.0, "nb:range"),
         ("20Y6M", 20.5, "nb:iso8601"),
         ("P20Y6M", 20.5, "nb:iso8601"),
         ("20Y9M", 20.75, "nb:iso8601"),
@@ -147,7 +146,6 @@ def test_age_gets_converted(raw_age, expected_age, heuristic):
     [
         ("11,0", "nb:float"),
         ("11.0", "nb:iso8601"),
-        ("11+", "nb:range"),
         ("20-30", "nb:bounded"),
     ],
 )


### PR DESCRIPTION
<!---
Until this PR is ready for review, you can include the [WIP] tag in its title, or leave it as a github draft.
-->






<!---
This is a suggested pull request template.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue
when this pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.

You can also just link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
Closes #129, closes #138.

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers
to indicate what they should be looking for when they review the pull request.
-->
Changes proposed in this pull request:

- Separate classes reimplemented for controlled terms, except they inherit from a common class (`ControlledTerm`)
- New test added which checks that in a CLI-outputted .jsonld, classes provided as `schemaKey` values for an attribute also have a definition in the `@context` (will help catch future occurrences of classes not defined explicitly in `models.py` appearing in the .jsonld as a namespace-less element)
- `nb:range` age heuristic removed


## Checklist

- [X] PR has an interpretable title with a prefix (`[ENH]`, `[BUG]`, `[DOC]`, `[INFRA]`, `[MAINT]`)
- [X] PR links to Github issue with mention `Closes #XXXX`
- [X] Tests pass
- [X] Code is properly formatted


For new features:
- [X] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.
  - N/A, bug fixed in this PR was not caught by original set of tests
