### PR TITLE
[FIX] Detect categorical column based on annotations

### DIFF
--- a/bagel/pheno_utils.py
+++ b/bagel/pheno_utils.py
@@ -106,7 +106,7 @@ def is_missing_value(
 
 def is_column_categorical(column: str, data_dict: dict) -> bool:
     """Determine whether a column in a Neurobagel data dictionary is categorical"""
-    if "Levels" in data_dict[column]:
+    if "Levels" in data_dict[column]["Annotations"]:
         return True
     return False
 

--- a/bagel/tests/test_utility.py
+++ b/bagel/tests/test_utility.py
@@ -69,6 +69,28 @@ def test_get_transformed_categorical_value(test_data, load_test_json):
     )
 
 
+def test_detect_categorical_column():
+    good_example = {
+        "column": {
+            "Annotations": {
+                "IsAbout": {
+                    "TermURL": "something",
+                    "Labels": "other"
+                },
+                "Levels": {
+                    "val1": {
+                        "TermURL": "something",
+                        "Label": "other"
+                    }
+                }
+            }
+        }
+    }
+    result = putil.is_column_categorical(column="column", data_dict=good_example)
+    
+    assert result is True
+
+
 @pytest.mark.parametrize(
     "value,column,expected",
     [

--- a/bagel/tests/test_utility.py
+++ b/bagel/tests/test_utility.py
@@ -86,18 +86,16 @@ def test_get_transformed_categorical_value(test_data, load_test_json):
             True,
         ),
         (
-{
+            {
                 "column": {
-"Levels": {
-                            "val1": "some description"
-                        },
+                    "Levels": {"val1": "some description"},
                     "Annotations": {
                         "IsAbout": {"TermURL": "something", "Labels": "other"}
-                    }
+                    },
                 }
             },
-            False
-        )
+            False,
+        ),
     ],
 )
 def test_detect_categorical_column(example, expected_result):

--- a/bagel/tests/test_utility.py
+++ b/bagel/tests/test_utility.py
@@ -69,26 +69,41 @@ def test_get_transformed_categorical_value(test_data, load_test_json):
     )
 
 
-def test_detect_categorical_column():
-    good_example = {
-        "column": {
-            "Annotations": {
-                "IsAbout": {
-                    "TermURL": "something",
-                    "Labels": "other"
-                },
-                "Levels": {
-                    "val1": {
-                        "TermURL": "something",
-                        "Label": "other"
+@pytest.mark.parametrize(
+    "example,expected_result",
+    [
+        (
+            {
+                "column": {
+                    "Annotations": {
+                        "IsAbout": {"TermURL": "something", "Labels": "other"},
+                        "Levels": {
+                            "val1": {"TermURL": "something", "Label": "other"}
+                        },
                     }
                 }
-            }
-        }
-    }
-    result = putil.is_column_categorical(column="column", data_dict=good_example)
-    
-    assert result is True
+            },
+            True,
+        ),
+        (
+{
+                "column": {
+"Levels": {
+                            "val1": "some description"
+                        },
+                    "Annotations": {
+                        "IsAbout": {"TermURL": "something", "Labels": "other"}
+                    }
+                }
+            },
+            False
+        )
+    ],
+)
+def test_detect_categorical_column(example, expected_result):
+    result = putil.is_column_categorical(column="column", data_dict=example)
+
+    assert result is expected_result
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!---
Until this PR is ready for review, you can include the [WIP] tag in its title, or leave it as a github draft.
-->






<!---
This is a suggested pull request template.
It's designed to capture information we've found to be useful in reviewing pull requests.

If there is other information that would be helpful to include, please don't hesitate to add it!
-->

<!-- Please indicate after the # which issue you're closing with this PR.
This is helpful for the maintainers AND will magically close the issue
when this pull request is merged!
If the PR closes multiple issues, includes "closes" before each one is listed.

You can also just link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
Closes #153 
See also #151 and #152

<!-- Please give a brief overview of what has changed in the PR.
If you're not sure what to write, consider it a note to the maintainers
to indicate what they should be looking for when they review the pull request.
-->
Changes proposed in this pull request:

- consider a column to be `categorical` inside the CLI **only** if there is a `"Levels"` key in the `"Annotations"` portion of the data dictionary

## Checklist

- [ ] PR has an interpretable title with a prefix (`[ENH]`, `[BUG]`, `[DOC]`, `[INFRA]`, `[MAINT]`)
- [x] PR links to Github issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Code is properly formatted


For new features:
- [x] Tests have been added

For bug fixes:
- [x] There is at least one test that would fail under the original bug conditions.
