### PR TITLE
[ENH] Provide overwritable output file path instead of directory path arg

### DIFF
--- a/bagel/cli.py
+++ b/bagel/cli.py
@@ -9,7 +9,7 @@ from pydantic import ValidationError
 import bagel.bids_utils as butil
 import bagel.pheno_utils as putil
 from bagel import mappings, models
-from bagel.utility import load_json
+from bagel.utility import check_overwrite, load_json
 
 bagel = typer.Typer()
 
@@ -65,6 +65,9 @@ def pheno(
     graph datamodel for the provided phenotypic file in the .jsonld format.
     You can upload this .jsonld file to the Neurobagel graph.
     """
+    # Check if output file already exists
+    check_overwrite(output, overwrite)
+
     data_dictionary = load_json(dictionary)
     pheno_df = pd.read_csv(pheno, sep="\t", keep_default_na=False, dtype=str)
     putil.validate_inputs(data_dictionary, pheno_df)
@@ -191,6 +194,9 @@ def bids(
     graph datamodel for the combined metadata in the .jsonld format.
     You can upload this .jsonld file to the Neurobagel graph.
     """
+    # Check if output file already exists
+    check_overwrite(output, overwrite)
+
     jsonld = load_json(jsonld_path)
     layout = BIDSLayout(bids_dir, validate=True)
 

--- a/bagel/cli.py
+++ b/bagel/cli.py
@@ -32,14 +32,6 @@ def pheno(
         dir_okay=False,
         resolve_path=True,
     ),
-    output: Path = typer.Option(
-        ...,
-        help="The directory where outputs should be created.",
-        exists=True,
-        file_okay=False,
-        dir_okay=True,
-        resolve_path=True,
-    ),
     name: str = typer.Option(
         ...,
         help="A descriptive name for the dataset the input belongs to. "
@@ -50,6 +42,18 @@ def pheno(
         default=None,
         callback=putil.validate_portal_uri,
         help="URL (HTTP/HTTPS) to a website or page that describes the dataset and access instructions (if available).",
+    ),
+    output: Path = typer.Option(
+        default="pheno.jsonld",
+        help="The path for the output .jsonld file.",
+        file_okay=True,
+        dir_okay=False,
+        resolve_path=True,
+    ),
+    overwrite: bool = typer.Option(
+        False,
+        "--overwrite",
+        help="Overwrite output file if it already exists.",
     ),
 ):
     """
@@ -166,12 +170,16 @@ def bids(
         resolve_path=True,
     ),
     output: Path = typer.Option(
-        ...,
-        help="The directory where outputs should be created",
-        exists=True,
-        file_okay=False,
-        dir_okay=True,
+        help="The path for the output .jsonld file.",
+        default="pheno_bids.jsonld",
+        file_okay=True,
+        dir_okay=False,
         resolve_path=True,
+    ),
+    overwrite: bool = typer.Option(
+        False,
+        "--overwrite",
+        help="Overwrite output file if it already exists.",
     ),
 ):
     """

--- a/bagel/cli.py
+++ b/bagel/cli.py
@@ -147,11 +147,10 @@ def pheno(
     # TODO: we should revisit this because there may be reasons to have None be meaningful in the future
     context.update(**dataset.dict(exclude_none=True))
 
-    output_filename = output / "pheno.jsonld"
-    with open(output_filename, "w") as f:
+    with open(output, "w") as f:
         f.write(json.dumps(context, indent=2))
 
-    print(f"Saved output to:  {output_filename}")
+    print(f"Saved output to:  {output}")
 
 
 @bagel.command()
@@ -278,8 +277,7 @@ def bids(
 
     merged_dataset = {**context, **pheno_dataset.dict(exclude_none=True)}
 
-    output_filename = output / "pheno_bids.jsonld"
-    with open(output_filename, "w") as f:
+    with open(output, "w") as f:
         f.write(json.dumps(merged_dataset, indent=2))
 
-    print(f"Saved output to:  {output_filename}")
+    print(f"Saved output to:  {output}")

--- a/bagel/tests/test_cli_bids.py
+++ b/bagel/tests/test_cli_bids.py
@@ -1,10 +1,21 @@
 from pathlib import Path
 
+import pytest
+
 from bagel.cli import bagel
 
 
+@pytest.fixture(scope="function")
+def default_pheno_bids_output_path(tmp_path):
+    "Return temporary bids command output filepath that uses the default filename."
+    return tmp_path / "pheno_bids.jsonld"
+
+
 def test_bids_valid_inputs_run_successfully(
-    runner, test_data_upload_path, bids_synthetic, tmp_path
+    runner,
+    test_data_upload_path,
+    bids_synthetic,
+    default_pheno_bids_output_path,
 ):
     """Basic smoke test for the "add-bids" subcommand"""
     result = runner.invoke(
@@ -16,12 +27,12 @@ def test_bids_valid_inputs_run_successfully(
             "--bids-dir",
             bids_synthetic,
             "--output",
-            tmp_path / "pheno_bids.jsonld",
+            default_pheno_bids_output_path,
         ],
     )
     assert result.exit_code == 0, f"Errored out. STDOUT: {result.output}"
     assert (
-        tmp_path / "pheno_bids.jsonld"
+        default_pheno_bids_output_path
     ).exists(), "The pheno_bids.jsonld output was not created."
 
 
@@ -29,7 +40,7 @@ def test_bids_sessions_have_correct_labels(
     runner,
     test_data_upload_path,
     bids_synthetic,
-    tmp_path,
+    default_pheno_bids_output_path,
     load_test_json,
 ):
     """Check that sessions added to pheno_bids.jsonld have the expected labels."""
@@ -42,11 +53,11 @@ def test_bids_sessions_have_correct_labels(
             "--bids-dir",
             bids_synthetic,
             "--output",
-            tmp_path / "pheno_bids.jsonld",
+            default_pheno_bids_output_path,
         ],
     )
 
-    pheno_bids = load_test_json(tmp_path / "pheno_bids.jsonld")
+    pheno_bids = load_test_json(default_pheno_bids_output_path)
     for sub in pheno_bids["hasSamples"]:
         assert ["ses-01", "ses-02"] == [
             ses["hasLabel"] for ses in sub["hasSession"]
@@ -56,7 +67,7 @@ def test_bids_sessions_have_correct_labels(
 def test_bids_data_with_sessions_have_correct_paths(
     runner,
     test_data_upload_path,
-    tmp_path,
+    default_pheno_bids_output_path,
     load_test_json,
 ):
     """
@@ -72,11 +83,11 @@ def test_bids_data_with_sessions_have_correct_paths(
             "--bids-dir",
             Path(__file__).parent / "../../bids-examples/synthetic",
             "--output",
-            tmp_path / "pheno_bids.jsonld",
+            default_pheno_bids_output_path,
         ],
     )
 
-    pheno_bids = load_test_json(tmp_path / "pheno_bids.jsonld")
+    pheno_bids = load_test_json(default_pheno_bids_output_path)
     for sub in pheno_bids["hasSamples"]:
         for ses in sub["hasSession"]:
             assert sub["hasLabel"] in ses["hasFilePath"]

--- a/bagel/tests/test_cli_bids.py
+++ b/bagel/tests/test_cli_bids.py
@@ -16,7 +16,7 @@ def test_bids_valid_inputs_run_successfully(
             "--bids-dir",
             bids_synthetic,
             "--output",
-            tmp_path,
+            tmp_path / "pheno_bids.jsonld",
         ],
     )
     assert result.exit_code == 0, f"Errored out. STDOUT: {result.output}"
@@ -42,7 +42,7 @@ def test_bids_sessions_have_correct_labels(
             "--bids-dir",
             bids_synthetic,
             "--output",
-            tmp_path,
+            tmp_path / "pheno_bids.jsonld",
         ],
     )
 
@@ -72,7 +72,7 @@ def test_bids_data_with_sessions_have_correct_paths(
             "--bids-dir",
             Path(__file__).parent / "../../bids-examples/synthetic",
             "--output",
-            tmp_path,
+            tmp_path / "pheno_bids.jsonld",
         ],
     )
 

--- a/bagel/tests/test_cli_pheno.py
+++ b/bagel/tests/test_cli_pheno.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 from bagel.cli import bagel
@@ -29,7 +31,7 @@ def test_pheno_valid_inputs_run_successfully(
                 "--dictionary",
                 test_data_upload_path / f"{example}.json",
                 "--output",
-                tmp_path,
+                tmp_path / "pheno.jsonld",
                 "--name",
                 "synthetic",
             ],
@@ -44,7 +46,7 @@ def test_pheno_valid_inputs_run_successfully(
                 "--dictionary",
                 test_data / f"{example}.json",
                 "--output",
-                tmp_path,
+                tmp_path / "pheno.jsonld",
                 "--name",
                 "do not care name",
             ],
@@ -106,7 +108,7 @@ def test_invalid_inputs_are_handled_gracefully(
                 "--dictionary",
                 test_data / f"{example}.json",
                 "--output",
-                tmp_path,
+                tmp_path / "pheno.jsonld",
                 "--name",
                 "do not care name",
             ],
@@ -142,7 +144,7 @@ def test_invalid_portal_uris_produces_error(
             "--dictionary",
             test_data / "example2.json",
             "--output",
-            tmp_path,
+            tmp_path / "pheno.jsonld",
             "--name",
             "test dataset 2",
             "--portal",
@@ -174,7 +176,7 @@ def test_missing_bids_levels_raises_warning(
                 "--dictionary",
                 test_data / "example12.json",
                 "--output",
-                tmp_path,
+                tmp_path / "pheno.jsonld",
                 "--name",
                 "testing dataset",
             ],
@@ -202,7 +204,7 @@ def test_bids_neurobagel_levels_mismatch_raises_warning(
                 "--dictionary",
                 test_data / "example13.json",
                 "--output",
-                tmp_path,
+                tmp_path / "pheno.jsonld",
                 "--name",
                 "testing dataset",
             ],
@@ -238,7 +240,7 @@ def test_unused_missing_values_raises_warning(
                 "--dictionary",
                 test_data / "example10.json",
                 "--output",
-                tmp_path,
+                tmp_path / "pheno.jsonld",
                 "--name",
                 "testing dataset",
             ],
@@ -267,7 +269,7 @@ def test_that_output_file_contains_dataset_level_attributes(
             "--dictionary",
             test_data / "example2.json",
             "--output",
-            tmp_path,
+            tmp_path / "pheno.jsonld",
             "--name",
             "my_dataset_name",
             "--portal",
@@ -293,7 +295,7 @@ def test_diagnosis_and_control_status_handled(
             "--dictionary",
             test_data / "example6.json",
             "--output",
-            tmp_path,
+            tmp_path / "pheno.jsonld",
             "--name",
             "my_dataset_name",
         ],
@@ -327,7 +329,7 @@ def test_controlled_terms_have_identifiers(
             "--dictionary",
             test_data_upload_path / "example_synthetic.json",
             "--output",
-            tmp_path,
+            tmp_path / "pheno.jsonld",
             "--name",
             "do not care name",
         ],
@@ -358,7 +360,7 @@ def test_controlled_term_classes_have_uri_type(
             "--dictionary",
             test_data_upload_path / "example_synthetic.json",
             "--output",
-            tmp_path,
+            tmp_path / "pheno.jsonld",
             "--name",
             "do not care name",
         ],
@@ -404,7 +406,7 @@ def test_assessment_data_are_parsed_correctly(
             "--dictionary",
             test_data / "example6.json",
             "--output",
-            tmp_path,
+            tmp_path / "pheno.jsonld",
             "--name",
             "my_dataset_name",
         ],
@@ -431,7 +433,7 @@ def test_cli_age_is_processed(
             "--dictionary",
             test_data / "example2.json",
             "--output",
-            tmp_path,
+            tmp_path / "pheno.jsonld",
             "--name",
             "my_dataset_name",
         ],
@@ -452,7 +454,7 @@ def test_output_includes_context(runner, test_data, tmp_path, load_test_json):
             "--dictionary",
             test_data / "example2.json",
             "--output",
-            tmp_path,
+            tmp_path / "pheno.jsonld",
             "--name",
             "my_dataset_name",
         ],
@@ -496,7 +498,7 @@ def test_output_excludes_properties_for_missing_vals(
             "--dictionary",
             test_data_upload_path / "example_synthetic.json",
             "--output",
-            tmp_path,
+            tmp_path / "pheno.jsonld",
             "--name",
             "BIDS synthetic test",
         ],
@@ -509,3 +511,23 @@ def test_output_excludes_properties_for_missing_vals(
                 assert (
                     sub.get(entry) is None
                 ), f"{sub_id} output contains value for {entry} where annotated as missing"
+
+
+def test_default_output_filename(runner, test_data_upload_path, tmp_path):
+    """Tests that the default output filename is used correctly when --output is not set."""
+    os.chdir(tmp_path)
+
+    runner.invoke(
+        bagel,
+        [
+            "pheno",
+            "--pheno",
+            test_data_upload_path / "example_synthetic.tsv",
+            "--dictionary",
+            test_data_upload_path / "example_synthetic.json",
+            "--name",
+            "BIDS synthetic test",
+        ],
+    )
+
+    assert (tmp_path / "pheno.jsonld").exists()

--- a/bagel/tests/test_cli_pheno.py
+++ b/bagel/tests/test_cli_pheno.py
@@ -531,3 +531,48 @@ def test_default_output_filename(runner, test_data_upload_path, tmp_path):
     )
 
     assert (tmp_path / "pheno.jsonld").exists()
+
+
+@pytest.mark.parametrize(
+    "overwrite_flag, expected_stdout",
+    [
+        ([], "already exists"),
+        (["--overwrite"], "Saved output to"),
+    ],
+)
+def test_overwrite_flag_behaviour(
+    runner, test_data_upload_path, tmp_path, overwrite_flag, expected_stdout
+):
+    """Tests that an existing output file is only overwritten if --overwrite is used."""
+    runner.invoke(
+        bagel,
+        [
+            "pheno",
+            "--pheno",
+            test_data_upload_path / "example_synthetic.tsv",
+            "--dictionary",
+            test_data_upload_path / "example_synthetic.json",
+            "--name",
+            "BIDS synthetic test",
+            "--output",
+            tmp_path / "synthetic_dataset.jsonld",
+        ],
+    )
+
+    overwrite_result = runner.invoke(
+        bagel,
+        [
+            "pheno",
+            "--pheno",
+            test_data_upload_path / "example_synthetic.tsv",
+            "--dictionary",
+            test_data_upload_path / "example_synthetic.json",
+            "--name",
+            "BIDS synthetic test",
+            "--output",
+            tmp_path / "synthetic_dataset.jsonld",
+        ]
+        + overwrite_flag,
+    )
+
+    assert expected_stdout in overwrite_result.output

--- a/bagel/utility.py
+++ b/bagel/utility.py
@@ -1,8 +1,21 @@
 import json
 from pathlib import Path
 
+import typer
+
 
 def load_json(input_p: Path) -> dict:
     """Load a user-specified json type file."""
     with open(input_p, "r") as f:
         return json.load(f)
+
+
+def check_overwrite(output: Path, overwrite: bool):
+    """Exit program gracefully if an output file already exists but --overwrite has not been set."""
+    if output.exists() and not overwrite:
+        raise typer.Exit(
+            typer.style(
+                f"Output file {output} already exists. Use --overwrite to overwrite.",
+                fg=typer.colors.RED,
+            )
+        )


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include the [WIP] tag in its title, or create a draft PR. -->


<!---
Below is a suggested pull request template.
It's designed to capture info we've found to be useful in reviewing pull requests, but feel free to add more details you feel are relevant/necessary.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
Closes #157

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- `--output` argument changed to specify a file path instead of a directory, and is no longer required for either command (defaults if unset are `pheno.jsonld`/`pheno_bids.jsonld`)
- `--overwrite` flag added which will overwrite an existing output file if set
  - if unset and the output file exists, program exits with informative message 
- new fixtures created for default output file path to use in tests

<!-- To be checked off by reviewers -->
## Checklist

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see https://neurobagel.org/contributing/pull_requests for more info)_
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass

For new features:
- [x] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.
