### PR TITLE
[REF] Refactor phenotypic/BIDS subjects check and add more intermediate stdout for `bagel bids`

### DIFF
--- a/bagel/bids_utils.py
+++ b/bagel/bids_utils.py
@@ -11,6 +11,19 @@ def map_term_to_namespace(term: str, namespace: dict) -> str:
     return namespace.get(term, False)
 
 
+def get_bids_subjects_simple(bids_dir: Path) -> list:
+    """Returns list of subject IDs (in format of sub-<SUBJECT>) for a BIDS directory inferred from the names of non-empty subdirectories."""
+    bids_subject_list = []
+    for path in bids_dir.iterdir():
+        if (
+            path.name.startswith("sub-")
+            and path.is_dir()
+            and any(path.iterdir())
+        ):
+            bids_subject_list.append(path.name)
+    return bids_subject_list
+
+
 def check_unique_bids_subjects(pheno_subjects: list, bids_subjects: list):
     """Raises informative error if subject IDs exist that are found only in the BIDS directory."""
     unique_bids_subjects = set(bids_subjects).difference(pheno_subjects)

--- a/bagel/cli.py
+++ b/bagel/cli.py
@@ -206,6 +206,12 @@ def bids(
     # (and can't be easily added) to the existing data model
     context = {"@context": jsonld.pop("@context")}
 
+    space = 32
+    print(
+        "Running initial checks of inputs...\n"
+        f"   {'Phenotypic .jsonld to augment:' : <{space}} {jsonld_path}\n"
+        f"   {'BIDS dataset directory:' : <{space}} {bids_dir}"
+    )
     try:
         pheno_dataset = models.Dataset.parse_obj(jsonld)
     except ValidationError as err:
@@ -221,14 +227,7 @@ def bids(
         pheno_subjects=pheno_subject_dict.keys(),
         bids_subjects=butil.get_bids_subjects_simple(bids_dir),
     )
-
-    # Display validated input paths to user
-    space = 32
-    print(
-        "Initial checks of inputs passed:\n"
-        f"   {'Phenotypic .jsonld to augment:' : <{space}} {jsonld_path}\n"
-        f"   {'BIDS dataset directory:' : <{space}} {bids_dir}\n"
-    )
+    print("Initial checks of inputs passed:\n")
 
     print("Parsing and validating BIDS dataset. This may take a while...")
     layout = BIDSLayout(bids_dir, validate=True)

--- a/bagel/cli.py
+++ b/bagel/cli.py
@@ -201,17 +201,17 @@ def bids(
     # Check if output file already exists
     check_overwrite(output, overwrite)
 
-    jsonld = load_json(jsonld_path)
-    # Strip and store context to be added back later, since it's not part of
-    # (and can't be easily added) to the existing data model
-    context = {"@context": jsonld.pop("@context")}
-
     space = 32
     print(
         "Running initial checks of inputs...\n"
         f"   {'Phenotypic .jsonld to augment:' : <{space}} {jsonld_path}\n"
         f"   {'BIDS dataset directory:' : <{space}} {bids_dir}"
     )
+
+    jsonld = load_json(jsonld_path)
+    # Strip and store context to be added back later, since it's not part of
+    # (and can't be easily added) to the existing data model
+    context = {"@context": jsonld.pop("@context")}
     try:
         pheno_dataset = models.Dataset.parse_obj(jsonld)
     except ValidationError as err:
@@ -227,7 +227,7 @@ def bids(
         pheno_subjects=pheno_subject_dict.keys(),
         bids_subjects=butil.get_bids_subjects_simple(bids_dir),
     )
-    print("Initial checks of inputs passed:\n")
+    print("Initial checks of inputs passed.\n")
 
     print("Parsing and validating BIDS dataset. This may take a while...")
     layout = BIDSLayout(bids_dir, validate=True)

--- a/bagel/tests/test_utility.py
+++ b/bagel/tests/test_utility.py
@@ -337,6 +337,22 @@ def test_generate_context(get_test_context, model, attributes):
 
 
 @pytest.mark.parametrize(
+    "bids_dir",
+    ["synthetic", "ds000248"],
+)
+def test_get_bids_subjects_simple(bids_path, bids_dir):
+    """Test that get_bids_subjects_simple() correctly extracts subject IDs from a BIDS directory."""
+    bids_subject_list = butil.get_bids_subjects_simple(bids_path / bids_dir)
+    expected_subjects = [
+        f"sub-{sub_id}"
+        for sub_id in BIDSLayout(
+            bids_path / bids_dir, validate=True
+        ).get_subjects()
+    ]
+    assert sorted(bids_subject_list) == sorted(expected_subjects)
+
+
+@pytest.mark.parametrize(
     "bids_list, expectation",
     [
         (["sub-01", "sub-02", "sub-03"], does_not_raise()),


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include the [WIP] tag in its title, or create a draft PR. -->


<!---
Below is a suggested pull request template.
It's designed to capture info we've found to be useful in reviewing pull requests, but feel free to add more details you feel are relevant/necessary.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
Closes #190 

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- Check for BIDS subject IDs missing from the phenotypic JSONLD _before_ slow `BIDSLayout` initialization
  - This is done by simply extracting BIDS subdirectory names (see #190 issue description for why pybids functions are limited here)
- Print more intermediate messages during `bagel bids` command to indicate program progress

<!-- To be checked off by reviewers -->
## Checklist

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see https://neurobagel.org/contributing/pull_requests for more info)_
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass

For new features:
- [x] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.
