### PR TITLE
[CI] Remove required status check from .autorc

### DIFF
--- a/.autorc
+++ b/.autorc
@@ -10,12 +10,7 @@
     "plugins": [
         "git-tag",
         "released",
-        [
-            "protected-branch",
-            {
-                "requiredStatusChecks": ["pre-commit.ci - pr"]
-            }
-        ],
+        "protected-branch",
         "first-time-contributor",
         [
             "omit-commits",


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the Neurobagel PR process and other contributing guidelines, see https://neurobagel.org/contributing/CONTRIBUTING/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- Auto-release wf is currently [failing](https://github.com/neurobagel/bagel-cli/actions/runs/10002197859/job/27673133238) because the required status check option for `protected-branch` apparently relies on PAT having the "Checks" permission, which is (amazingly) currently [not supported](https://github.com/orgs/community/discussions/129512) even though it is [documented](https://docs.github.com/en/rest/guides/using-the-rest-api-to-interact-with-checks?apiVersion=2022-11-28#about-check-runs)
- As a workaround, we will try to remove the status check option from the `auto` config, and apply it in the repo setting instead to trigger the check

<!-- To be checked off by reviewers -->
## Checklist
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING#pull-request-guidelines) for more info)_
- [x] PR has a label for the release changelog or `skip-release` (to be applied by maintainers only)
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.
