### PR TITLE
[FIX] Add missing `_id` suffix to processing status file column mappings

### DIFF
--- a/bagel/derivatives_utils.py
+++ b/bagel/derivatives_utils.py
@@ -6,7 +6,7 @@ from bagel import mappings, models
 
 # Shorthands for expected column names in a Nipoppy processing status file
 # TODO: While there are multiple session ID columns in a Nipoppy processing status file,
-# we only only look at `bids_session` right now. We should revisit this after the schema is finalized,
+# we only only look at `bids_session_id` right now. We should revisit this after the schema is finalized,
 # to see if any other logic is needed to avoid issues with session ID discrepancies across columns.
 PROC_STATUS_COLS = {
     "participant": "bids_participant_id",

--- a/bagel/derivatives_utils.py
+++ b/bagel/derivatives_utils.py
@@ -9,8 +9,8 @@ from bagel import mappings, models
 # we only only look at `bids_session` right now. We should revisit this after the schema is finalized,
 # to see if any other logic is needed to avoid issues with session ID discrepancies across columns.
 PROC_STATUS_COLS = {
-    "participant": "bids_participant",
-    "session": "bids_session",
+    "participant": "bids_participant_id",
+    "session": "bids_session_id",
     "pipeline_name": "pipeline_name",
     "pipeline_version": "pipeline_version",
     "status": "status",

--- a/bagel/tests/data/README.md
+++ b/bagel/tests/data/README.md
@@ -39,7 +39,7 @@ Example file `proc_status`... | Description | Expected result
 _synthetic.tsv | Captures a subset of subject-sessions represented in the BIDS examples synthetic dataset | Pass
 _synthetic.csv | Same as proc_status_synthetic.csv, but is a CSV file | Fail
 _unique_subs.tsv | Includes subjects not found in the phenotypic dataset | Fail
-_incomplete.tsv | Has a missing value in the `bids_participant` column | Fail
+_incomplete.tsv | Has a missing value in the `bids_participant_id` column | Fail
 _unique_sessions.csv | Includes a unique subject-session (`sub-01`, `ses-03`) not found in the synthetic dataset | Pass
 _missing_sessions.tsv | One subject (`sub-02`) is missing all session labels | Pass
 _no_bids_sessions.tsv | Has session labels in all rows for `session_id`, but no values in `bids_session` column | Pass

--- a/bagel/tests/data/README.md
+++ b/bagel/tests/data/README.md
@@ -42,7 +42,7 @@ _unique_subs.tsv | Includes subjects not found in the phenotypic dataset | Fail
 _incomplete.tsv | Has a missing value in the `bids_participant_id` column | Fail
 _unique_sessions.csv | Includes a unique subject-session (`sub-01`, `ses-03`) not found in the synthetic dataset | Pass
 _missing_sessions.tsv | One subject (`sub-02`) is missing all session labels | Pass
-_no_bids_sessions.tsv | Has session labels in all rows for `session_id`, but no values in `bids_session` column | Pass
+_no_bids_sessions.tsv | Has session labels in all rows for `session_id`, but no values in `bids_session_id` column | Pass
 
 
 ## Example expected CLI outputs

--- a/bagel/tests/data/proc_status_missing_sessions.tsv
+++ b/bagel/tests/data/proc_status_missing_sessions.tsv
@@ -1,4 +1,4 @@
-participant_id	bids_participant	session_id	bids_session	pipeline_name	pipeline_version	pipeline_step	status
+participant_id	bids_participant_id	session_id	bids_session_id	pipeline_name	pipeline_version	pipeline_step	status
 01	sub-01	01	ses-01	fmriprep	20.2.7	step1	SUCCESS
 01	sub-01	01	ses-01	fmriprep	20.2.7	step2	SUCCESS
 01	sub-01	01	ses-01	fmriprep	23.1.3	default	SUCCESS

--- a/bagel/tests/data/proc_status_no_bids_sessions.tsv
+++ b/bagel/tests/data/proc_status_no_bids_sessions.tsv
@@ -1,4 +1,4 @@
-participant_id	bids_participant	session_id	bids_session	pipeline_name	pipeline_version	pipeline_step	status
+participant_id	bids_participant_id	session_id	bids_session_id	pipeline_name	pipeline_version	pipeline_step	status
 01	sub-01	01		fmriprep	20.2.7	step1	SUCCESS
 01	sub-01	01		fmriprep	20.2.7	step2	SUCCESS
 01	sub-01	01		fmriprep	23.1.3	default	SUCCESS

--- a/bagel/tests/data/proc_status_synthetic.csv
+++ b/bagel/tests/data/proc_status_synthetic.csv
@@ -1,4 +1,4 @@
-participant_id,bids_participant,session_id,bids_session,pipeline_name,pipeline_version,pipeline_step,status
+participant_id,bids_participant_id,session_id,bids_session_id,pipeline_name,pipeline_version,pipeline_step,status
 01,sub-01,1,ses-01,fmriprep,20.2.7,step1,FAIL
 01,sub-01,1,ses-01,fmriprep,20.2.7,step2,INCOMPLETE
 01,sub-01,1,ses-01,fmriprep,23.1.3,default,SUCCESS

--- a/bagel/tests/data/proc_status_synthetic.tsv
+++ b/bagel/tests/data/proc_status_synthetic.tsv
@@ -1,4 +1,4 @@
-participant_id	bids_participant	session_id	bids_session	pipeline_name	pipeline_version	pipeline_step	status
+participant_id	bids_participant_id	session_id	bids_session_id	pipeline_name	pipeline_version	pipeline_step	status
 01	sub-01	01	ses-01	fmriprep	20.2.7	step1	FAIL
 01	sub-01	01	ses-01	fmriprep	20.2.7	step2	INCOMPLETE
 01	sub-01	01	ses-01	fmriprep	23.1.3	default	SUCCESS

--- a/bagel/tests/data/proc_status_synthetic_incomplete.tsv
+++ b/bagel/tests/data/proc_status_synthetic_incomplete.tsv
@@ -1,4 +1,4 @@
-participant_id	bids_participant	session_id	bids_session	pipeline_name	pipeline_version	pipeline_step	status
+participant_id	bids_participant_id	session_id	bids_session_id	pipeline_name	pipeline_version	pipeline_step	status
 01	sub-01	01	ses-01	fmriprep	20.2.7	step1	FAIL
 01	sub-01	01	ses-01	fmriprep	20.2.7	step2	INCOMPLETE
 01	sub-01	01	ses-01	fmriprep	23.1.3	default	SUCCESS

--- a/bagel/tests/data/proc_status_unique_sessions.tsv
+++ b/bagel/tests/data/proc_status_unique_sessions.tsv
@@ -1,4 +1,4 @@
-participant_id	bids_participant	session_id	bids_session	pipeline_name	pipeline_version	pipeline_step	status
+participant_id	bids_participant_id	session_id	bids_session_id	pipeline_name	pipeline_version	pipeline_step	status
 01	sub-01	01	ses-01	fmriprep	20.2.7	step1	FAIL
 01	sub-01	01	ses-01	fmriprep	20.2.7	step2	INCOMPLETE
 01	sub-01	03	ses-03	fmriprep	23.1.3	default	SUCCESS

--- a/bagel/tests/data/proc_status_unique_subs.tsv
+++ b/bagel/tests/data/proc_status_unique_subs.tsv
@@ -1,4 +1,4 @@
-participant_id	bids_participant	session_id	bids_session	pipeline_name	pipeline_version	pipeline_step	status
+participant_id	bids_participant_id	session_id	bids_session_id	pipeline_name	pipeline_version	pipeline_step	status
 pd1	sub-pd1	01	ses-01	fmriprep	20.2.7	step1	FAIL
 pd1	sub-pd1	01	ses-01	fmriprep	20.2.7	step2	INCOMPLETE
 pd2	sub-pd2	01	ses-01	fmriprep	23.1.3	default	SUCCESS

--- a/bagel/tests/test_cli_derivatives.py
+++ b/bagel/tests/test_cli_derivatives.py
@@ -161,7 +161,7 @@ def test_derivatives_invalid_inputs_fail(
         # TODO: Revisit this example once the updated Nipoppy proc status file schema is available
         # This example assumes that
         # 1. It is possible to have a subject with missing values in bids_session but not in session_id
-        # 2. Duplicate entries of pipeline name, version, and step for an apparent subject-session based on bids_participant and bids_session
+        # 2. Duplicate entries of pipeline name, version, and step for an apparent subject-session based on bids_participant_id and bids_session_id
         # (i.e., the two columns Neurobagel looks at) are allowed (see rows 8 and 9)
         ("proc_status_no_bids_sessions.tsv", {"sub-01": 3, "sub-02": 2}),
     ],

--- a/bagel/tests/test_cli_derivatives.py
+++ b/bagel/tests/test_cli_derivatives.py
@@ -160,7 +160,7 @@ def test_derivatives_invalid_inputs_fail(
         ("proc_status_missing_sessions.tsv", {"sub-02": 2}),
         # TODO: Revisit this example once the updated Nipoppy proc status file schema is available
         # This example assumes that
-        # 1. It is possible to have a subject with missing values in bids_session but not in session_id
+        # 1. It is possible to have a subject with missing values in bids_session_id but not in session_id
         # 2. Duplicate entries of pipeline name, version, and step for an apparent subject-session based on bids_participant_id and bids_session_id
         # (i.e., the two columns Neurobagel looks at) are allowed (see rows 8 and 9)
         ("proc_status_no_bids_sessions.tsv", {"sub-01": 3, "sub-02": 2}),

--- a/bagel/tests/test_utility.py
+++ b/bagel/tests/test_utility.py
@@ -761,9 +761,9 @@ def test_create_completed_pipelines():
     example_ses_proc_df = pd.DataFrame.from_records(
         columns=[
             "participant_id",
-            "bids_participant",
+            "bids_participant_id",
             "session_id",
-            "bids_session",
+            "bids_session_id",
             "pipeline_name",
             "pipeline_version",
             "pipeline_step",


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the Neurobagel PR process and other contributing guidelines, see https://neurobagel.org/contributing/CONTRIBUTING/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Fixes #369

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- Since https://github.com/nipoppy/nipoppy/pull/382, the Nipoppy processing status file now uses column names `bids_participant_id` and `bids_session_id` instead of `bids_participant` and `bids_session`. This PR brings the column names expected internally by the CLI for this file into alignment with the Nipoppy schema.

<!-- To be checked off by reviewers -->
## Checklist
_This section is for the PR reviewer_

- [ ] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING#pull-request-guidelines) for more info)_
- [ ] PR has a label for the release changelog or `skip-release` (to be applied by maintainers only)
- [ ] PR links to GitHub issue with mention `Closes #XXXX`
- [ ] Tests pass
- [ ] Checks pass

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.
