### PR TITLE
[ENH] Allow unrecognized pipeline names and versions in processing status file

### DIFF
--- a/bagel/cli.py
+++ b/bagel/cli.py
@@ -414,7 +414,6 @@ def derivatives(
             f"We found missing values in the following rows (first row is zero): {row_indices}."
         )
 
-    # TODO: Do we need to check all versions across all pipelines first, and report all unrecognized versions together?
     derivative_utils.check_at_least_one_pipeline_version_is_recognized(
         status_df=status_df
     )

--- a/bagel/cli.py
+++ b/bagel/cli.py
@@ -414,18 +414,10 @@ def derivatives(
             f"We found missing values in the following rows (first row is zero): {row_indices}."
         )
 
-    pipelines = status_df[PROC_STATUS_COLS["pipeline_name"]].unique()
-    derivative_utils.check_pipelines_are_recognized(pipelines)
-
     # TODO: Do we need to check all versions across all pipelines first, and report all unrecognized versions together?
-    for pipeline in pipelines:
-        versions = status_df[
-            status_df[PROC_STATUS_COLS["pipeline_name"]] == pipeline
-        ][PROC_STATUS_COLS["pipeline_version"]].unique()
-
-        derivative_utils.check_pipeline_versions_are_recognized(
-            pipeline, versions
-        )
+    derivative_utils.check_at_least_one_pipeline_version_is_recognized(
+        status_df=status_df
+    )
 
     jsonld_dataset = model_utils.extract_and_validate_jsonld_dataset(
         jsonld_path

--- a/bagel/mappings.py
+++ b/bagel/mappings.py
@@ -73,7 +73,7 @@ def get_pipeline_catalog(url: str, path: Path) -> list[dict]:
             ) from e
 
 
-def parse_pipeline_catalog():
+def parse_pipeline_catalog() -> tuple[dict, dict]:
     """
     Load the pipeline catalog and return a dictionary of pipeline names and their URIs in the Nipoppy namespace,
     and a dictionary of pipeline names and their supported versions in Nipoppy.

--- a/bagel/utilities/derivative_utils.py
+++ b/bagel/utilities/derivative_utils.py
@@ -74,7 +74,6 @@ def check_at_least_one_pipeline_version_is_recognized(status_df: pd.DataFrame):
         "For a full list, see https://github.com/nipoppy/pipeline-catalog."
     )
 
-    # TODO: Handle error in this func here as well?
     recognized_pipelines = get_recognized_pipelines(
         status_df[PROC_STATUS_COLS["pipeline_name"]].unique()
     )

--- a/bagel/utilities/derivative_utils.py
+++ b/bagel/utilities/derivative_utils.py
@@ -69,6 +69,7 @@ def check_at_least_one_pipeline_version_is_recognized(status_df: pd.DataFrame):
     """
     Check that at least one pipeline name and version combination found in the processing status file is supported by Nipoppy.
     """
+
     more_info_message = (
         "Allowed processing pipelines and versions are those supported natively in Nipoppy. "
         "For a full list, see https://github.com/nipoppy/pipeline-catalog."
@@ -78,7 +79,7 @@ def check_at_least_one_pipeline_version_is_recognized(status_df: pd.DataFrame):
         status_df[PROC_STATUS_COLS["pipeline_name"]].unique()
     )
 
-    any_recognized_versions = 0
+    any_recognized_versions = False
     unrecognized_pipeline_versions = {}
     for pipeline in recognized_pipelines:
         versions = status_df[
@@ -89,8 +90,10 @@ def check_at_least_one_pipeline_version_is_recognized(status_df: pd.DataFrame):
             validate_pipeline_versions(pipeline, versions)
         )
 
-        any_recognized_versions += len(recognized_versions)
-        if len(unrecognized_versions) > 0:
+        if recognized_versions:
+            any_recognized_versions = True
+
+        if unrecognized_versions:
             unrecognized_pipeline_versions[pipeline] = unrecognized_versions
 
     if not any_recognized_versions:

--- a/bagel/utilities/derivative_utils.py
+++ b/bagel/utilities/derivative_utils.py
@@ -25,7 +25,7 @@ def get_recognized_pipelines(pipelines: Iterable[str]) -> list:
     """
     allowed_pipelines_message = (
         f"Allowed pipeline names are the following pipelines supported natively in Nipoppy (https://github.com/nipoppy/pipeline-catalog):\n"
-        f"{mappings.KNOWN_PIPELINE_URIS.keys()}"
+        f"{list(mappings.KNOWN_PIPELINE_URIS.keys())}"
     )
     recognized_pipelines = list(
         set(pipelines).intersection(mappings.KNOWN_PIPELINE_URIS)
@@ -97,7 +97,7 @@ def check_at_least_one_pipeline_version_is_recognized(status_df: pd.DataFrame):
     if total_recognized_versions == 0:
         # TODO: Consider simply exiting with a message and no output instead?
         raise LookupError(
-            f"The processing status file contains no recognized versions of any pipelines in the column '{PROC_STATUS_COLS['pipeline_version']}'.\n"
+            f"The processing status file contains no recognized versions of {recognized_pipelines} in the column '{PROC_STATUS_COLS['pipeline_version']}'.\n"
             f"{more_info_message}"
         )
     if len(unrecognized_pipeline_versions) > 0:

--- a/bagel/utilities/derivative_utils.py
+++ b/bagel/utilities/derivative_utils.py
@@ -34,7 +34,7 @@ def get_recognized_pipelines(pipelines: Iterable[str]) -> list:
         set(pipelines).difference(mappings.KNOWN_PIPELINE_URIS)
     )
 
-    if len(recognized_pipelines) == 0:
+    if not recognized_pipelines:
         raise LookupError(
             f"The processing status file contains no recognized pipelines in the column '{PROC_STATUS_COLS['pipeline_name']}'.\n"
             f"{allowed_pipelines_message}"
@@ -78,7 +78,7 @@ def check_at_least_one_pipeline_version_is_recognized(status_df: pd.DataFrame):
         status_df[PROC_STATUS_COLS["pipeline_name"]].unique()
     )
 
-    total_recognized_versions = 0
+    any_recognized_versions = 0
     unrecognized_pipeline_versions = {}
     for pipeline in recognized_pipelines:
         versions = status_df[
@@ -89,11 +89,11 @@ def check_at_least_one_pipeline_version_is_recognized(status_df: pd.DataFrame):
             classify_pipeline_versions(pipeline, versions)
         )
 
-        total_recognized_versions += len(recognized_versions)
+        any_recognized_versions += len(recognized_versions)
         if len(unrecognized_versions) > 0:
             unrecognized_pipeline_versions[pipeline] = unrecognized_versions
 
-    if total_recognized_versions == 0:
+    if not any_recognized_versions:
         # TODO: Consider simply exiting with a message and no output instead?
         raise LookupError(
             f"The processing status file contains no recognized versions of {recognized_pipelines} in the column '{PROC_STATUS_COLS['pipeline_version']}'.\n"

--- a/bagel/utilities/derivative_utils.py
+++ b/bagel/utilities/derivative_utils.py
@@ -23,10 +23,6 @@ def get_recognized_pipelines(pipelines: Iterable[str]) -> list:
     Check that all pipelines in the processing status file are supported by Nipoppy.
     Raise an error if all pipelines are unrecognized, otherwise warn about unrecognized pipelines.
     """
-    allowed_pipelines_message = (
-        f"Allowed pipeline names are the following pipelines supported natively in Nipoppy (https://github.com/nipoppy/pipeline-catalog):\n"
-        f"{list(mappings.KNOWN_PIPELINE_URIS.keys())}"
-    )
     recognized_pipelines = list(
         set(pipelines).intersection(mappings.KNOWN_PIPELINE_URIS)
     )
@@ -34,16 +30,20 @@ def get_recognized_pipelines(pipelines: Iterable[str]) -> list:
         set(pipelines).difference(mappings.KNOWN_PIPELINE_URIS)
     )
 
+    unrecognized_pipelines_template = (
+        f"Unrecognized processing pipelines: {unrecognized_pipelines}\n"
+        f"Supported pipelines are those in the Nipoppy pipeline catalog (https://github.com/nipoppy/pipeline-catalog):\n"
+        f"{list(mappings.KNOWN_PIPELINE_URIS.keys())}"
+    )
     if not recognized_pipelines:
         raise LookupError(
-            f"The processing status file contains no recognized pipelines in the column '{PROC_STATUS_COLS['pipeline_name']}'.\n"
-            f"{allowed_pipelines_message}"
+            f"The processing status file contains no recognized pipelines in the column: '{PROC_STATUS_COLS['pipeline_name']}'.\n"
+            f"{unrecognized_pipelines_template}"
         )
     if unrecognized_pipelines:
         warnings.warn(
-            f"The processing status file contains unrecognized pipelines in the column '{PROC_STATUS_COLS['pipeline_name']}': "
-            f"{unrecognized_pipelines}. These will be ignored.\n"
-            f"{allowed_pipelines_message}"
+            f"The processing status file contains unrecognized pipelines in the column: '{PROC_STATUS_COLS['pipeline_name']}'. These will be ignored.\n"
+            f"{unrecognized_pipelines_template}"
         )
     return recognized_pipelines
 

--- a/bagel/utilities/derivative_utils.py
+++ b/bagel/utilities/derivative_utils.py
@@ -25,7 +25,7 @@ def get_recognized_pipelines(pipelines: Iterable[str]) -> list:
     """
     allowed_pipelines_message = (
         f"Allowed pipeline names are the following pipelines supported natively in Nipoppy (https://github.com/nipoppy/pipeline-catalog):\n"
-        f"{mappings.KNOWN_PIPELINE_URIS}"
+        f"{mappings.KNOWN_PIPELINE_URIS.keys()}"
     )
     recognized_pipelines = list(
         set(pipelines).intersection(mappings.KNOWN_PIPELINE_URIS)

--- a/bagel/utilities/derivative_utils.py
+++ b/bagel/utilities/derivative_utils.py
@@ -39,7 +39,7 @@ def get_recognized_pipelines(pipelines: Iterable[str]) -> list:
             f"The processing status file contains no recognized pipelines in the column '{PROC_STATUS_COLS['pipeline_name']}'.\n"
             f"{allowed_pipelines_message}"
         )
-    if len(unrecognized_pipelines) > 0:
+    if unrecognized_pipelines:
         warnings.warn(
             f"The processing status file contains unrecognized pipelines in the column '{PROC_STATUS_COLS['pipeline_name']}': "
             f"{unrecognized_pipelines}. These will be ignored.\n"
@@ -99,7 +99,7 @@ def check_at_least_one_pipeline_version_is_recognized(status_df: pd.DataFrame):
             f"The processing status file contains no recognized versions of {recognized_pipelines} in the column '{PROC_STATUS_COLS['pipeline_version']}'.\n"
             f"{more_info_message}"
         )
-    if len(unrecognized_pipeline_versions) > 0:
+    if unrecognized_pipeline_versions:
         warnings.warn(
             f"The processing status file contains unrecognized versions of the following pipelines in the column '{PROC_STATUS_COLS['pipeline_version']}': "
             f"{unrecognized_pipeline_versions}. These will be ignored.\n"

--- a/bagel/utilities/derivative_utils.py
+++ b/bagel/utilities/derivative_utils.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Iterable
 
 import pandas as pd
@@ -17,35 +18,89 @@ PROC_STATUS_COLS = {
 }
 
 
-def check_pipelines_are_recognized(pipelines: Iterable[str]):
+# TODO: Rename
+def check_pipelines_are_recognized(pipelines: Iterable[str]) -> list:
     """Check that all pipelines in the processing status file are supported by Nipoppy."""
+    allowed_pipelines_message = (
+        f"Allowed pipeline names are the following pipelines supported natively in Nipoppy (https://github.com/nipoppy/pipeline-catalog):\n"
+        f"{mappings.KNOWN_PIPELINE_URIS}"
+    )
+    recognized_pipelines = list(
+        set(pipelines).intersection(mappings.KNOWN_PIPELINE_URIS)
+    )
     unrecognized_pipelines = list(
         set(pipelines).difference(mappings.KNOWN_PIPELINE_URIS)
     )
-    if len(unrecognized_pipelines) > 0:
+
+    if len(recognized_pipelines) == 0:
         raise LookupError(
-            f"The processing status file contains unrecognized pipelines in the column '{PROC_STATUS_COLS['pipeline_name']}': "
-            f"{unrecognized_pipelines}. "
-            f"Allowed pipeline names are the following pipelines supported natively in Nipoppy (https://github.com/nipoppy/pipeline-catalog): \n"
-            f"{mappings.KNOWN_PIPELINE_URIS}"
+            f"The processing status file contains no recognized pipelines in the column '{PROC_STATUS_COLS['pipeline_name']}'.\n"
+            f"{allowed_pipelines_message}"
         )
+    if len(unrecognized_pipelines) > 0:
+        warnings.warn(
+            f"The processing status file contains unrecognized pipelines in the column '{PROC_STATUS_COLS['pipeline_name']}': "
+            f"{unrecognized_pipelines}. These will be ignored.\n"
+            f"{allowed_pipelines_message}"
+        )
+    return recognized_pipelines
 
 
+# TODO: Rename
 def check_pipeline_versions_are_recognized(
     pipeline: str, versions: Iterable[str]
-):
+) -> tuple[list, list]:
     """
     Check that all pipeline versions in the processing status file are supported by Nipoppy.
     Assumes that the input pipeline name is recognized.
     """
+    recognized_versions = list(
+        set(versions).intersection(mappings.KNOWN_PIPELINE_VERSIONS[pipeline])
+    )
     unrecognized_versions = list(
         set(versions).difference(mappings.KNOWN_PIPELINE_VERSIONS[pipeline])
     )
-    if len(unrecognized_versions) > 0:
+
+    return recognized_versions, unrecognized_versions
+
+
+def check_at_least_one_pipeline_version_is_recognized(status_df: pd.DataFrame):
+    more_info_message = (
+        "Allowed processing pipelines and versions are those supported natively in Nipoppy. "
+        "For a full list, see https://github.com/nipoppy/pipeline-catalog."
+    )
+
+    # TODO: Handle error in this func here as well?
+    recognized_pipelines = check_pipelines_are_recognized(
+        status_df[PROC_STATUS_COLS["pipeline_name"]].unique()
+    )
+
+    total_num_recognized_versions = 0
+    unrecognized_pipeline_versions = {}
+    for pipeline in recognized_pipelines:
+        versions = status_df[
+            status_df[PROC_STATUS_COLS["pipeline_name"]] == pipeline
+        ][PROC_STATUS_COLS["pipeline_version"]].unique()
+
+        recognized_versions, unrecognized_versions = (
+            check_pipeline_versions_are_recognized(pipeline, versions)
+        )
+
+        total_num_recognized_versions += len(recognized_versions)
+        if len(unrecognized_versions) > 0:
+            unrecognized_pipeline_versions[pipeline] = unrecognized_versions
+
+    if total_num_recognized_versions == 0:
+        # TODO: Consider simply exiting with a message and no output instead?
         raise LookupError(
-            f"The processing status file contains unrecognized {pipeline} versions in the column '{PROC_STATUS_COLS['pipeline_version']}': {unrecognized_versions}. "
-            f"Allowed {pipeline} versions are the following versions supported natively in Nipoppy (https://github.com/nipoppy/pipeline-catalog): \n"
-            f"{mappings.KNOWN_PIPELINE_VERSIONS[pipeline]}"
+            f"The processing status file contains no recognized versions of any pipelines in the column '{PROC_STATUS_COLS['pipeline_version']}'.\n"
+            f"{more_info_message}"
+        )
+    if len(unrecognized_pipeline_versions) > 0:
+        warnings.warn(
+            f"The processing status file contains unrecognized versions of the following pipelines in the column '{PROC_STATUS_COLS['pipeline_version']}': "
+            f"{unrecognized_pipeline_versions}. These will be ignored.\n"
+            f"{more_info_message}"
         )
 
 
@@ -61,17 +116,21 @@ def create_completed_pipelines(session_proc_df: pd.DataFrame) -> list:
             PROC_STATUS_COLS["pipeline_version"],
         ]
     ):
-        # Check that all pipeline steps have succeeded
         if (
-            session_pipe_df[PROC_STATUS_COLS["status"]].str.lower()
-            == "success"
-        ).all():
-            completed_pipeline = models.CompletedPipeline(
-                hasPipelineName=models.Pipeline(
-                    identifier=mappings.KNOWN_PIPELINE_URIS[pipeline]
-                ),
-                hasPipelineVersion=version,
-            )
-            completed_pipelines.append(completed_pipeline)
+            pipeline in mappings.KNOWN_PIPELINE_URIS
+            and version in mappings.KNOWN_PIPELINE_VERSIONS[pipeline]
+        ):
+            # Check that all pipeline steps have succeeded
+            if (
+                session_pipe_df[PROC_STATUS_COLS["status"]].str.lower()
+                == "success"
+            ).all():
+                completed_pipeline = models.CompletedPipeline(
+                    hasPipelineName=models.Pipeline(
+                        identifier=mappings.KNOWN_PIPELINE_URIS[pipeline]
+                    ),
+                    hasPipelineVersion=version,
+                )
+                completed_pipelines.append(completed_pipeline)
 
     return completed_pipelines

--- a/bagel/utilities/derivative_utils.py
+++ b/bagel/utilities/derivative_utils.py
@@ -122,18 +122,16 @@ def create_completed_pipelines(session_proc_df: pd.DataFrame) -> list:
         if (
             pipeline in mappings.KNOWN_PIPELINE_URIS
             and version in mappings.KNOWN_PIPELINE_VERSIONS[pipeline]
-        ):
-            # Check that all pipeline steps have succeeded
-            if (
-                session_pipe_df[PROC_STATUS_COLS["status"]].str.lower()
-                == "success"
-            ).all():
-                completed_pipeline = models.CompletedPipeline(
-                    hasPipelineName=models.Pipeline(
-                        identifier=mappings.KNOWN_PIPELINE_URIS[pipeline]
-                    ),
-                    hasPipelineVersion=version,
-                )
-                completed_pipelines.append(completed_pipeline)
+        ) and (
+            session_pipe_df[PROC_STATUS_COLS["status"]].str.lower()
+            == "success"
+        ).all():
+            completed_pipeline = models.CompletedPipeline(
+                hasPipelineName=models.Pipeline(
+                    identifier=mappings.KNOWN_PIPELINE_URIS[pipeline]
+                ),
+                hasPipelineVersion=version,
+            )
+            completed_pipelines.append(completed_pipeline)
 
     return completed_pipelines

--- a/bagel/utilities/derivative_utils.py
+++ b/bagel/utilities/derivative_utils.py
@@ -19,7 +19,10 @@ PROC_STATUS_COLS = {
 
 
 def get_recognized_pipelines(pipelines: Iterable[str]) -> list:
-    """Check that all pipelines in the processing status file are supported by Nipoppy."""
+    """
+    Check that all pipelines in the processing status file are supported by Nipoppy.
+    Raise an error if all pipelines are unrecognized, otherwise warn about unrecognized pipelines.
+    """
     allowed_pipelines_message = (
         f"Allowed pipeline names are the following pipelines supported natively in Nipoppy (https://github.com/nipoppy/pipeline-catalog):\n"
         f"{mappings.KNOWN_PIPELINE_URIS}"
@@ -49,8 +52,8 @@ def classify_pipeline_versions(
     pipeline: str, versions: Iterable[str]
 ) -> tuple[list, list]:
     """
-    Check that all pipeline versions in the processing status file are supported by Nipoppy.
-    Assumes that the input pipeline name is recognized.
+    For a given pipeline, return the recognized and unrecognized pipeline versions in the processing status file
+    based on the Nipoppy pipeline-catalog, and return both as lists.
     """
     recognized_versions = list(
         set(versions).intersection(mappings.KNOWN_PIPELINE_VERSIONS[pipeline])

--- a/bagel/utilities/derivative_utils.py
+++ b/bagel/utilities/derivative_utils.py
@@ -53,7 +53,7 @@ def classify_pipeline_versions(
 ) -> tuple[list, list]:
     """
     For a given pipeline, return the recognized and unrecognized pipeline versions in the processing status file
-    based on the Nipoppy pipeline-catalog, and return both as lists.
+    based on the Nipoppy pipeline catalog, and return both as lists.
     """
     recognized_versions = list(
         set(versions).intersection(mappings.KNOWN_PIPELINE_VERSIONS[pipeline])

--- a/bagel/utilities/derivative_utils.py
+++ b/bagel/utilities/derivative_utils.py
@@ -48,7 +48,7 @@ def get_recognized_pipelines(pipelines: Iterable[str]) -> list:
     return recognized_pipelines
 
 
-def classify_pipeline_versions(
+def validate_pipeline_versions(
     pipeline: str, versions: Iterable[str]
 ) -> tuple[list, list]:
     """
@@ -86,7 +86,7 @@ def check_at_least_one_pipeline_version_is_recognized(status_df: pd.DataFrame):
         ][PROC_STATUS_COLS["pipeline_version"]].unique()
 
         recognized_versions, unrecognized_versions = (
-            classify_pipeline_versions(pipeline, versions)
+            validate_pipeline_versions(pipeline, versions)
         )
 
         any_recognized_versions += len(recognized_versions)

--- a/tests/data/README.md
+++ b/tests/data/README.md
@@ -43,6 +43,9 @@ _incomplete.tsv | Has a missing value in the `bids_participant_id` column | Fail
 _unique_sessions.csv | Includes a unique subject-session (`sub-01`, `ses-03`) not found in the synthetic dataset | Pass
 _missing_sessions.tsv | One subject (`sub-02`) is missing all session labels | Pass
 _no_bids_sessions.tsv | Has session labels in all rows for `session_id`, but no values in `bids_session_id` column | Pass
+_unrecognized_pipelines.tsv | Includes some pipeline names and versions not found in the pipeline catalog | Pass
+_no_recognized_pipelines.tsv | Includes pipeline names found in the pipeline catalog, but no recognized versions | Fail 
+
 
 
 ## Example expected CLI outputs

--- a/tests/data/proc_status_no_recognized_pipelines.tsv
+++ b/tests/data/proc_status_no_recognized_pipelines.tsv
@@ -1,0 +1,6 @@
+participant_id	bids_participant_id	session_id	bids_session_id	pipeline_name	pipeline_version	pipeline_step	status
+01	sub-01	01	ses-01	fmriprep	unknown.version1	step1	FAIL
+01	sub-01	01	ses-01	fmriprep	unknown.version1	step2	INCOMPLETE
+01	sub-01	01	ses-01	fmriprep	unknown.version2	default	SUCCESS
+01	sub-01	01	ses-01	freesurfer	unknown.version3	default	SUCCESS
+01	sub-01	02	ses-02	freesurfer	unknown.version3	default	UNAVAILABLE

--- a/tests/data/proc_status_unrecognized_pipelines.tsv
+++ b/tests/data/proc_status_unrecognized_pipelines.tsv
@@ -1,0 +1,6 @@
+participant_id	bids_participant_id	session_id	bids_session_id	pipeline_name	pipeline_version	pipeline_step	status
+01	sub-01	01	ses-01	fmriprep	unknown.version	step1	FAIL
+01	sub-01	01	ses-01	fmriprep	unknown.version	step2	INCOMPLETE
+01	sub-01	01	ses-01	unknown-pipeline	1.0.0	default	SUCCESS
+01	sub-01	01	ses-01	freesurfer	7.3.2	default	SUCCESS
+01	sub-01	02	ses-02	freesurfer	7.3.2	default	UNAVAILABLE

--- a/tests/integration/test_cli_derivatives.py
+++ b/tests/integration/test_cli_derivatives.py
@@ -238,13 +238,13 @@ def test_unrecognized_pipelines_and_versions_excluded_from_output(
 
     assert len(w) == 2
     warnings = [warning.message.args[0] for warning in w]
-    for warn_substrings in [
-        ("unrecognized pipelines", "unknown-pipeline"),
-        ("unrecognized versions", "{'fmriprep': ['unknown.version']}"),
-    ]:
-        assert any(
-            all(substr in warning for substr in warn_substrings)
-            for warning in warnings
+    for warning in warnings:
+        assert (
+            "unrecognized pipelines" in warning
+            and "unknown-pipeline" in warning
+        ) or (
+            "unrecognized versions" in warning
+            and "{'fmriprep': ['unknown.version']}" in warning
         )
 
     output = load_test_json(default_derivatives_output_path)

--- a/tests/integration/test_cli_derivatives.py
+++ b/tests/integration/test_cli_derivatives.py
@@ -261,8 +261,8 @@ def test_unrecognized_pipelines_and_versions_excluded_from_output(
                         "hasCompletedPipeline"
                     ]
 
+    ses01_completed_pipes = sessions_with_completed_pipes.get("ses-01")
     assert sessions_with_completed_pipes.keys() == {"ses-01"}
-    ses01_completed_pipes = sessions_with_completed_pipes["ses-01"]
     assert len(ses01_completed_pipes) == 1
     assert (
         ses01_completed_pipes[0]["hasPipelineName"]["identifier"]

--- a/tests/integration/test_cli_derivatives.py
+++ b/tests/integration/test_cli_derivatives.py
@@ -2,6 +2,7 @@ from collections import defaultdict
 
 import pytest
 
+from bagel import mappings
 from bagel.cli import bagel
 
 
@@ -205,3 +206,66 @@ def test_custom_imaging_sessions_created_for_missing_session_labels(
 
     # Note: order of items does not matter for dict comparison
     assert custom_ses_completed_pipes == completed_pipes_for_missing_ses_sub
+
+
+def test_unrecognized_pipelines_excluded_from_output(
+    runner,
+    test_data,
+    test_data_upload_path,
+    default_derivatives_output_path,
+    load_test_json,
+):
+    """
+    Test that when a subset of pipelines or versions from a processing status file are unrecognized,
+    they are excluded from the output JSONLD with informative warnings, without causing the derivatives command to fail.
+    """
+    with pytest.warns(UserWarning) as w:
+        result = runner.invoke(
+            bagel,
+            [
+                "derivatives",
+                "-t",
+                test_data / "proc_status_unrecognized_pipelines.tsv",
+                "-p",
+                test_data_upload_path / "example_synthetic.jsonld",
+                "-o",
+                default_derivatives_output_path,
+            ],
+            catch_exceptions=False,
+        )
+
+    assert result.exit_code == 0, f"Errored out. STDOUT: {result.output}"
+
+    assert len(w) == 2
+    warnings = [warning.message.args[0] for warning in w]
+    for warn_substrings in [
+        ("unrecognized pipelines", "unknown-pipeline"),
+        ("unrecognized versions", "{'fmriprep': ['unknown.version']}"),
+    ]:
+        assert any(
+            all(substr in warning for substr in warn_substrings)
+            for warning in warnings
+        )
+
+    output = load_test_json(default_derivatives_output_path)
+
+    sessions_with_completed_pipes = {}
+    for sub in output["hasSamples"]:
+        if sub["hasLabel"] == "sub-01":
+            for ses in sub["hasSession"]:
+                if (
+                    ses["schemaKey"] == "ImagingSession"
+                    and "hasCompletedPipeline" in ses
+                ):
+                    sessions_with_completed_pipes[ses["hasLabel"]] = ses[
+                        "hasCompletedPipeline"
+                    ]
+
+    assert sessions_with_completed_pipes.keys() == {"ses-01"}
+    ses01_completed_pipes = sessions_with_completed_pipes["ses-01"]
+    assert len(ses01_completed_pipes) == 1
+    assert (
+        ses01_completed_pipes[0]["hasPipelineName"]["identifier"]
+        == f"{mappings.NP.pf}:freesurfer"
+    )
+    assert ses01_completed_pipes[0]["hasPipelineVersion"] == "7.3.2"

--- a/tests/unit/test_derivative_utils.py
+++ b/tests/unit/test_derivative_utils.py
@@ -146,26 +146,24 @@ def test_error_raised_when_no_pipeline_names_recognized():
     assert "no recognized pipelines" in str(e.value)
 
 
-# @pytest.mark.parametrize(
-#     "fmriprep_versions, unrecog_versions",
-#     [
-#         (["20.2.7", "vA.B"], ["vA.B"]),
-#         (["C.D.E", "F.G.H"], ["C.D.E", "F.G.H"]),
-#     ],
-# )
-# def test_unrecognized_pipeline_versions_raise_error(
-#     fmriprep_versions, unrecog_versions
-# ):
-#     """Test that versions of a pipeline not found in the pipeline catalog raise an informative error."""
-#     with pytest.raises(LookupError) as e:
-#         derivative_utils.classify_pipeline_versions(
-#             "fmriprep", fmriprep_versions
-#         )
-
-#     assert all(
-#         substr in str(e.value)
-#         for substr in ["unrecognized fmriprep versions"] + unrecog_versions
-#     )
+@pytest.mark.parametrize(
+    "fmriprep_versions, expctd_recog_versions, expctd_unrecog_versions",
+    [
+        (["20.2.7", "vA.B"], ["20.2.7"], ["vA.B"]),
+        (["C.D.E", "F.G.H"], [], ["C.D.E", "F.G.H"]),
+    ],
+)
+def test_pipeline_versions_classified_correctly(
+    fmriprep_versions, expctd_recog_versions, expctd_unrecog_versions
+):
+    """Test that versions of a pipeline are correctly classified as recognized or unrecognized according to the pipeline catalog."""
+    recog_versions, unrecog_versions = (
+        derivative_utils.classify_pipeline_versions(
+            "fmriprep", fmriprep_versions
+        )
+    )
+    assert recog_versions == expctd_recog_versions
+    assert unrecog_versions == expctd_unrecog_versions
 
 
 def test_create_completed_pipelines():

--- a/tests/unit/test_derivative_utils.py
+++ b/tests/unit/test_derivative_utils.py
@@ -124,7 +124,7 @@ def test_pipeline_versions_are_loaded():
 def test_unrecognized_pipeline_names_raise_error(pipelines, unrecog_pipelines):
     """Test that pipeline names not found in the pipeline catalog raise an informative error."""
     with pytest.raises(LookupError) as e:
-        derivative_utils.check_pipelines_are_recognized(pipelines)
+        derivative_utils.get_recognized_pipelines(pipelines)
 
     assert all(
         substr in str(e.value)
@@ -144,7 +144,7 @@ def test_unrecognized_pipeline_versions_raise_error(
 ):
     """Test that versions of a pipeline not found in the pipeline catalog raise an informative error."""
     with pytest.raises(LookupError) as e:
-        derivative_utils.check_pipeline_versions_are_recognized(
+        derivative_utils.classify_pipeline_versions(
             "fmriprep", fmriprep_versions
         )
 

--- a/tests/unit/test_derivative_utils.py
+++ b/tests/unit/test_derivative_utils.py
@@ -162,8 +162,9 @@ def test_pipeline_versions_classified_correctly(
             "fmriprep", fmriprep_versions
         )
     )
-    assert recog_versions == expctd_recog_versions
-    assert unrecog_versions == expctd_unrecog_versions
+    # The order of the versions in the lists is not guaranteed
+    assert set(recog_versions) == set(expctd_recog_versions)
+    assert set(unrecog_versions) == set(expctd_unrecog_versions)
 
 
 def test_create_completed_pipelines():

--- a/tests/unit/test_derivative_utils.py
+++ b/tests/unit/test_derivative_utils.py
@@ -158,7 +158,7 @@ def test_pipeline_versions_classified_correctly(
 ):
     """Test that versions of a pipeline are correctly classified as recognized or unrecognized according to the pipeline catalog."""
     recog_versions, unrecog_versions = (
-        derivative_utils.classify_pipeline_versions(
+        derivative_utils.validate_pipeline_versions(
             "fmriprep", fmriprep_versions
         )
     )

--- a/tests/unit/test_derivative_utils.py
+++ b/tests/unit/test_derivative_utils.py
@@ -147,14 +147,14 @@ def test_error_raised_when_no_pipeline_names_recognized():
 
 
 @pytest.mark.parametrize(
-    "fmriprep_versions, expctd_recog_versions, expctd_unrecog_versions",
+    "fmriprep_versions, expected_recog_versions, expected_unrecog_versions",
     [
         (["20.2.7", "vA.B"], ["20.2.7"], ["vA.B"]),
         (["C.D.E", "F.G.H"], [], ["C.D.E", "F.G.H"]),
     ],
 )
 def test_pipeline_versions_classified_correctly(
-    fmriprep_versions, expctd_recog_versions, expctd_unrecog_versions
+    fmriprep_versions, expected_recog_versions, expected_unrecog_versions
 ):
     """Test that versions of a pipeline are correctly classified as recognized or unrecognized according to the pipeline catalog."""
     recog_versions, unrecog_versions = (
@@ -163,8 +163,8 @@ def test_pipeline_versions_classified_correctly(
         )
     )
     # The order of the versions in the lists is not guaranteed
-    assert set(recog_versions) == set(expctd_recog_versions)
-    assert set(unrecog_versions) == set(expctd_unrecog_versions)
+    assert set(recog_versions) == set(expected_recog_versions)
+    assert set(unrecog_versions) == set(expected_unrecog_versions)
 
 
 def test_create_completed_pipelines():


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the Neurobagel PR process and other contributing guidelines, see https://neurobagel.org/contributing/CONTRIBUTING/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #382 

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- Checks of pipeline names and versions updated so that:
  - If no available pipeline names are recognized, error out, otherwise emit a warning and continue
  - For each recognized pipeline, emit a warning if >=1 versions are unrecognized and continue
    - If no versions of any recognized pipelines are themselves recognized, error out

**For reviewer:** Sourcery was super verbose on this PR because it seemingly reviewed it twice (I accidentally marked the PR  ready for review before I was ready, and then once I converted to draft and then back to ready for review, the old comments stuck around even though several were no longer applicable). Not sure how to make Sourcery auto-resolve old reviews - I attempted to do it using a command but that only triggered yet another review 😬 To make this PR easier to read, I've left only the most recent set of comments unresolved.

<!-- To be checked off by reviewers -->
## Checklist
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING#pull-request-guidelines) for more info)_
- [x] PR has a label for the release changelog or `skip-release` (to be applied by maintainers only)
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass

For new features:
- [x] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.

## Summary by Sourcery

Enhance the processing status file handling by allowing unrecognized pipeline names and versions, emitting warnings instead of errors when some are unrecognized, and ensuring at least one recognized pipeline-version combination is present. Update tests to cover these scenarios.

Enhancements:
- Update pipeline name and version checks to allow unrecognized entries, emitting warnings instead of errors when some are unrecognized.

Tests:
- Add tests to ensure unrecognized pipelines and versions are excluded from output with warnings, and that errors are raised when no recognized pipeline-version combinations exist.

## Summary by Sourcery

Enhance the processing status file handling by allowing unrecognized pipeline names and versions, emitting warnings instead of errors when some are unrecognized, and ensuring at least one recognized pipeline-version combination is present. Update tests to cover these scenarios.

Enhancements:
- Update pipeline name and version checks to allow unrecognized entries, emitting warnings instead of errors when some are unrecognized.

Tests:
- Add tests to ensure unrecognized pipelines and versions are excluded from output with warnings, and that errors are raised when no recognized pipeline-version combinations exist.