### PR TITLE
[MNT] Remind about missing value annotation in age parsing error

### DIFF
--- a/bagel/utilities/pheno_utils.py
+++ b/bagel/utilities/pheno_utils.py
@@ -154,7 +154,8 @@ def transform_age(value: str, heuristic: str) -> float:
     except (ValueError, isodate.isoerror.ISO8601Error) as e:
         raise ValueError(
             f"There was a problem with applying the age transformation: {heuristic}. "
-            "Check that the specified transformation is correct for the age values in your data dictionary."
+            "Check that the transformation specified in the data dictionary is correct for the age values in your phenotypic file, "
+            "and that you correctly annotated any missing values in your age column."
         ) from e
     if not is_recognized_heuristic:
         raise ValueError(

--- a/bagel/utilities/pheno_utils.py
+++ b/bagel/utilities/pheno_utils.py
@@ -153,8 +153,8 @@ def transform_age(value: str, heuristic: str) -> float:
             is_recognized_heuristic = False
     except (ValueError, isodate.isoerror.ISO8601Error) as e:
         raise ValueError(
-            f"There was a problem with applying the age transformation: {heuristic}. "
-            "Check that the transformation specified in the data dictionary is correct for the age values in your phenotypic file, "
+            f"There was a problem with applying the age transformation: {heuristic}. Error: {str(e)}\n"
+            f"Check that the transformation specified in the data dictionary ({heuristic}) is correct for the age values in your phenotypic file, "
             "and that you correctly annotated any missing values in your age column."
         ) from e
     if not is_recognized_heuristic:


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the Neurobagel PR process and other contributing guidelines, see https://neurobagel.org/contributing/CONTRIBUTING/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #397 

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->

<!-- To be checked off by reviewers -->
## Checklist
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING#pull-request-guidelines) for more info)_
- [x] PR has a label for the release changelog or `skip-release` (to be applied by maintainers only)
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.

## Summary by Sourcery

Bug Fixes:
- Improve error message in age transformation to remind users to annotate missing values in the age column.