### PR TITLE
[FIX] Disallow empty string/whitespace-only `pheno --name` values

### DIFF
--- a/bagel/cli.py
+++ b/bagel/cli.py
@@ -56,8 +56,8 @@ def pheno(
         "-n",
         callback=pheno_utils.validate_dataset_name,
         help="The full name of the dataset. "
-        "This name will be displayed when the dataset matches a Neurobagel query. "
-        "For a dataset with BIDS data, should ideally match the dataset_description.json 'name' field. "
+        "This name will be displayed when users discover the dataset in a Neurobagel query. "
+        "For a dataset with BIDS data, the name should ideally match the dataset_description.json 'name' field. "
         'Enclose in quotes, e.g.: --name "my dataset name"',
     ),
     portal: str = typer.Option(

--- a/bagel/cli.py
+++ b/bagel/cli.py
@@ -54,6 +54,7 @@ def pheno(
         ...,
         "--name",
         "-n",
+        callback=pheno_utils.validate_dataset_name,
         help="A descriptive name for the dataset the input belongs to. "
         "This name is expected to match the name field in the BIDS dataset_description.json file. "
         'Should be enclosed in quotes, e.g.: --name "my dataset name"',

--- a/bagel/cli.py
+++ b/bagel/cli.py
@@ -55,9 +55,10 @@ def pheno(
         "--name",
         "-n",
         callback=pheno_utils.validate_dataset_name,
-        help="A descriptive name for the dataset the input belongs to. "
-        "This name is expected to match the name field in the BIDS dataset_description.json file. "
-        'Should be enclosed in quotes, e.g.: --name "my dataset name"',
+        help="The full name of the dataset. "
+        "This name will be displayed when the dataset matches a Neurobagel query. "
+        "For a dataset with BIDS data, should ideally match the dataset_description.json 'name' field. "
+        'Enclose in quotes, e.g.: --name "my dataset name"',
     ),
     portal: str = typer.Option(
         None,

--- a/bagel/utilities/pheno_utils.py
+++ b/bagel/utilities/pheno_utils.py
@@ -28,6 +28,13 @@ AGE_HEURISTICS = {
 }
 
 
+def validate_dataset_name(name: str) -> str:
+    """Custom validation that dataset name is not an empty string or just whitespace."""
+    if name.isspace() or name == "":
+        raise BadParameter("Dataset name cannot be an empty string.")
+    return name
+
+
 def validate_portal_uri(portal: Optional[str]) -> Optional[str]:
     """Custom validation that portal is a valid HttpUrl"""
     # NOTE: We need Optional in the validation type below to account for --portal being an optional argument in the pheno command

--- a/tests/integration/test_cli_pheno.py
+++ b/tests/integration/test_cli_pheno.py
@@ -880,3 +880,38 @@ def test_pheno_command_succeeds_with_short_option_names(
     assert (
         default_pheno_output_path
     ).exists(), "The pheno.jsonld output was not created."
+
+
+@pytest.mark.parametrize(
+    "invalid_dataset_name",
+    [
+        "",
+        "    ",
+        "\n\t",
+    ],
+)
+def test_empty_string_dataset_name_raises_error(
+    runner,
+    test_data_upload_path,
+    default_pheno_output_path,
+    invalid_dataset_name,
+):
+    """Ensure that provided dataset names cannot be empty strings or only contain whitespace."""
+    result = runner.invoke(
+        bagel,
+        [
+            "pheno",
+            "--pheno",
+            test_data_upload_path / "example_synthetic.tsv",
+            "--dictionary",
+            test_data_upload_path / "example_synthetic.json",
+            "--output",
+            default_pheno_output_path,
+            "--name",
+            invalid_dataset_name,
+        ],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code != 0
+    assert "cannot be an empty string" in result.output


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the Neurobagel PR process and other contributing guidelines, see https://neurobagel.org/contributing/CONTRIBUTING/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Fixes #418 

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- Add custom validation to check that the value of `--name` is not `""` or whitespace
- Clarify in help text that `--name` determines the dataset display name in Neurobagel query results

<!-- To be checked off by reviewers -->
## Checklist
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING#pull-request-guidelines) for more info)_
- [x] PR has a label for the release changelog or `skip-release` (to be applied by maintainers only)
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass

For new features:
- [x] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.

## Summary by Sourcery

Validate the dataset name passed to the `pheno` command to ensure it is not an empty string or whitespace. Update the help text to clarify that the name is used as the dataset display name in Neurobagel query results.

Bug Fixes:
- Prevent an error where an empty string or whitespace-only value could be provided for the dataset name in the `pheno` command.

Tests:
- Add tests to verify that an empty string or whitespace-only value for the `--name` argument results in an error.