### PR TITLE
[ENH] Support ranged ages with `nb:FromRange`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
       - id: check-toml
 
   - repo: https://github.com/pycqa/isort
-    rev: 6.0.0
+    rev: 6.0.1
     hooks:
       - id: isort
         args: 

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 # `bagel-cli`
 
-![GitHub branch check runs](https://img.shields.io/github/check-runs/neurobagel/bagel-cli/main?style=flat-square)
-![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/neurobagel/bagel-cli/test.yml?branch=main&style=flat-square&label=tests)
-![Codecov](https://img.shields.io/codecov/c/github/neurobagel/bagel-cli?token=R1KI9KIP8D&style=flat-square&logo=codecov&link=https%3A%2F%2Fcodecov.io%2Fgh%2Fneurobagel%2Fbagel-cli)
-![Static Badge](https://img.shields.io/badge/python-3.10%20%7C%203.11-blue?style=flat-square&logo=python)
-![GitHub License](https://img.shields.io/github/license/neurobagel/bagel-cli?style=flat-square&color=purple&link=LICENSE)
-![Docker Image Version (tag)](https://img.shields.io/docker/v/neurobagel/bagelcli/latest?style=flat-square&logo=docker&link=https%3A%2F%2Fhub.docker.com%2Fr%2Fneurobagel%2Fbagelcli%2Ftags)
-![Docker Pulls](https://img.shields.io/docker/pulls/neurobagel/bagelcli?style=flat-square&logo=docker&link=https%3A%2F%2Fhub.docker.com%2Fr%2Fneurobagel%2Fbagelcli%2Ftags)
+[![Main branch checks status](https://img.shields.io/github/check-runs/neurobagel/bagel-cli/main?style=flat-square&logo=github)](https://github.com/neurobagel/bagel-cli/actions?query=branch:main)
+[![Tests status](https://img.shields.io/github/actions/workflow/status/neurobagel/bagel-cli/test.yml?branch=main&style=flat-square&logo=github&label=tests)](https://github.com/neurobagel/bagel-cli/actions/workflows/test.yml)
+[![Codecov](https://img.shields.io/codecov/c/github/neurobagel/bagel-cli?token=R1KI9KIP8D&style=flat-square&logo=codecov&link=https%3A%2F%2Fcodecov.io%2Fgh%2Fneurobagel%2Fbagel-cli)](https://app.codecov.io/gh/neurobagel/bagel-cli)
+[![Python versions static](https://img.shields.io/badge/python-3.10%20%7C%203.11-blue?style=flat-square&logo=python)](https://www.python.org)
+[![License](https://img.shields.io/github/license/neurobagel/bagel-cli?style=flat-square&color=purple&link=LICENSE)](LICENSE)
+[![Docker Image Version (tag)](https://img.shields.io/docker/v/neurobagel/bagelcli/latest?style=flat-square&logo=docker&link=https%3A%2F%2Fhub.docker.com%2Fr%2Fneurobagel%2Fbagelcli%2Ftags)](https://hub.docker.com/r/neurobagel/bagelcli/tags)
+[![Docker Pulls](https://img.shields.io/docker/pulls/neurobagel/bagelcli?style=flat-square&logo=docker&link=https%3A%2F%2Fhub.docker.com%2Fr%2Fneurobagel%2Fbagelcli%2Ftags)](https://hub.docker.com/r/neurobagel/bagelcli/tags)
 
 </div>
 

--- a/bagel/utilities/pheno_utils.py
+++ b/bagel/utilities/pheno_utils.py
@@ -25,6 +25,7 @@ AGE_HEURISTICS = {
     "euro": NB.pf + ":FromEuro",
     "bounded": NB.pf + ":FromBounded",
     "iso8601": NB.pf + ":FromISO8601",
+    "range": NB.pf + ":FromRange",
 }
 
 
@@ -206,6 +207,8 @@ def transform_age(value: str, heuristic: str) -> float:
                 value = "P" + value
             duration = isodate.parse_duration(value)
             return float(duration.years + duration.months / 12)
+        if heuristic == AGE_HEURISTICS["range"]:
+            return sum(map(float, value.split("-"))) / 2
         raise ValueError(
             f"The provided data dictionary contains an unrecognized age transformation: {heuristic}. "
             f"Ensure that the transformation TermURL is one of {list(AGE_HEURISTICS.values())}."

--- a/bagel/utilities/pheno_utils.py
+++ b/bagel/utilities/pheno_utils.py
@@ -217,7 +217,8 @@ def transform_age(value: str, heuristic: str) -> float:
         raise ValueError(
             f"There was a problem with applying the age transformation: {heuristic}. Error: {str(e)}\n"
             f"Check that the transformation specified in the data dictionary ({heuristic}) is correct for the age values in your phenotypic file, "
-            "and that you correctly annotated any missing values in your age column."
+            "and that you correctly annotated any missing values in your age column. "
+            "For examples of acceptable values for specific age transformations, see https://neurobagel.org/data_models/dictionaries/#age."
         ) from e
 
 

--- a/bagel/utilities/pheno_utils.py
+++ b/bagel/utilities/pheno_utils.py
@@ -19,7 +19,7 @@ from bagel.mappings import (
 
 DICTIONARY_SCHEMA = dictionary_models.DataDictionary.model_json_schema()
 
-AGE_HEURISTICS = {
+AGE_FORMATS = {
     "float": NB.pf + ":FromFloat",
     "int": NB.pf + ":FromInt",
     "euro": NB.pf + ":FromEuro",
@@ -187,36 +187,36 @@ def map_cat_val_to_term(
     return data_dict[column]["Annotations"]["Levels"][value]["TermURL"]
 
 
-def get_age_heuristic(column: str, data_dict: dict) -> str:
+def get_age_format(column: str, data_dict: dict) -> str:
     return data_dict[column]["Annotations"]["Transformation"]["TermURL"]
 
 
-def transform_age(value: str, heuristic: str) -> float:
+def transform_age(value: str, value_format: str) -> float:
     try:
-        if heuristic in [
-            AGE_HEURISTICS["float"],
-            AGE_HEURISTICS["int"],
+        if value_format in [
+            AGE_FORMATS["float"],
+            AGE_FORMATS["int"],
         ]:
             return float(value)
-        if heuristic == AGE_HEURISTICS["euro"]:
+        if value_format == AGE_FORMATS["euro"]:
             return float(value.replace(",", "."))
-        if heuristic == AGE_HEURISTICS["bounded"]:
+        if value_format == AGE_FORMATS["bounded"]:
             return float(value.strip("+"))
-        if heuristic == AGE_HEURISTICS["iso8601"]:
+        if value_format == AGE_FORMATS["iso8601"]:
             if not value.startswith("P"):
                 value = "P" + value
             duration = isodate.parse_duration(value)
             return float(duration.years + duration.months / 12)
-        if heuristic == AGE_HEURISTICS["range"]:
+        if value_format == AGE_FORMATS["range"]:
             return sum(map(float, value.split("-"))) / 2
         raise ValueError(
-            f"The provided data dictionary contains an unrecognized age transformation: {heuristic}. "
-            f"Ensure that the transformation TermURL is one of {list(AGE_HEURISTICS.values())}."
+            f"The provided data dictionary contains an unrecognized age transformation: {value_format}. "
+            f"Ensure that the transformation TermURL is one of {list(AGE_FORMATS.values())}."
         )
     except (ValueError, isodate.isoerror.ISO8601Error) as e:
         raise ValueError(
-            f"There was a problem with applying the age transformation: {heuristic}. Error: {str(e)}\n"
-            f"Check that the transformation specified in the data dictionary ({heuristic}) is correct for the age values in your phenotypic file, "
+            f"There was a problem with applying the age transformation: {value_format}. Error: {str(e)}\n"
+            f"Check that the transformation specified in the data dictionary ({value_format}) is correct for the age values in your phenotypic file, "
             "and that you correctly annotated any missing values in your age column. "
             "For examples of acceptable values for specific age transformations, see https://neurobagel.org/data_models/dictionaries/#age."
         ) from e
@@ -237,7 +237,7 @@ def get_transformed_values(
             # TODO: replace with more flexible solution when we have more
             # continuous variables than just age
             transf_vals.append(
-                transform_age(str(value), get_age_heuristic(col, data_dict))
+                transform_age(str(value), get_age_format(col, data_dict))
             )
 
     return transf_vals

--- a/bagel/utilities/pheno_utils.py
+++ b/bagel/utilities/pheno_utils.py
@@ -204,18 +204,21 @@ def transform_age(value: str, value_format: str) -> float:
             return float(value.strip("+"))
         if value_format == AGE_FORMATS["iso8601"]:
             if not value.startswith("P"):
-                value = "P" + value
-            duration = isodate.parse_duration(value)
+                pvalue = "P" + value
+            else:
+                pvalue = value
+            duration = isodate.parse_duration(pvalue)
             return float(duration.years + duration.months / 12)
         if value_format == AGE_FORMATS["range"]:
-            return sum(map(float, value.split("-"))) / 2
+            a_min, a_max = value.split("-")
+            return sum(map(float, [a_min, a_max])) / 2
         raise ValueError(
             f"The provided data dictionary contains an unrecognized age transformation: {value_format}. "
             f"Ensure that the transformation TermURL is one of {list(AGE_FORMATS.values())}."
         )
     except (ValueError, isodate.isoerror.ISO8601Error) as e:
         raise ValueError(
-            f"There was a problem with applying the age transformation: {value_format}. Error: {str(e)}\n"
+            f"There was a problem with applying the transformation {value_format} to the age: {value}. Error: {str(e)}\n"
             f"Check that the transformation specified in the data dictionary ({value_format}) is correct for the age values in your phenotypic file, "
             "and that you correctly annotated any missing values in your age column. "
             "For examples of acceptable values for specific age transformations, see https://neurobagel.org/data_models/dictionaries/#age."

--- a/tests/unit/test_pheno_utils.py
+++ b/tests/unit/test_pheno_utils.py
@@ -339,7 +339,7 @@ def test_missing_ids_in_columns(test_data, columns, expected_indices):
         ("P20Y6M", 20.5, "nb:FromISO8601"),
         ("20Y9M", 20.75, "nb:FromISO8601"),
         ("20-25", 22.5, "nb:FromRange"),
-        ("20.5-25.5", 23.0, "nb:FromRange"),
+        ("20.00-25.00", 22.5, "nb:FromRange"),
     ],
 )
 def test_age_gets_converted(raw_age, expected_age, heuristic):

--- a/tests/unit/test_pheno_utils.py
+++ b/tests/unit/test_pheno_utils.py
@@ -338,6 +338,7 @@ def test_missing_ids_in_columns(test_data, columns, expected_indices):
         ("20Y6M", 20.5, "nb:FromISO8601"),
         ("P20Y6M", 20.5, "nb:FromISO8601"),
         ("20Y9M", 20.75, "nb:FromISO8601"),
+        ("20-25", 22.5, "nb:FromRange"),
     ],
 )
 def test_age_gets_converted(raw_age, expected_age, heuristic):
@@ -350,6 +351,7 @@ def test_age_gets_converted(raw_age, expected_age, heuristic):
         ("11,0", "nb:FromFloat"),
         ("11.0", "nb:FromISO8601"),
         ("20-30", "nb:FromBounded"),
+        ("20+", "nb:FromRange"),
     ],
 )
 def test_incorrect_age_heuristic(raw_age, incorrect_heuristic):

--- a/tests/unit/test_pheno_utils.py
+++ b/tests/unit/test_pheno_utils.py
@@ -352,7 +352,9 @@ def test_age_gets_converted(raw_age, expected_age, value_format):
         ("11,0", "nb:FromFloat"),
         ("11.0", "nb:FromISO8601"),
         ("20-30", "nb:FromBounded"),
-        ("20+", "nb:FromRange"),
+        ("20", "nb:FromRange"),
+        ("20-", "nb:FromRange"),
+        ("-30", "nb:FromRange"),
     ],
 )
 def test_incorrect_age_format(raw_age, incorrect_format):
@@ -361,7 +363,7 @@ def test_incorrect_age_format(raw_age, incorrect_format):
         pheno_utils.transform_age(raw_age, incorrect_format)
 
     assert (
-        f"problem with applying the age transformation: {incorrect_format}."
+        f"problem with applying the transformation {incorrect_format} to the age: {raw_age}"
         in str(e.value)
     )
 

--- a/tests/unit/test_pheno_utils.py
+++ b/tests/unit/test_pheno_utils.py
@@ -329,7 +329,7 @@ def test_missing_ids_in_columns(test_data, columns, expected_indices):
 
 
 @pytest.mark.parametrize(
-    "raw_age,expected_age,heuristic",
+    "raw_age,expected_age,value_format",
     [
         ("11.0", 11.0, "nb:FromFloat"),
         ("11", 11.0, "nb:FromInt"),
@@ -342,12 +342,12 @@ def test_missing_ids_in_columns(test_data, columns, expected_indices):
         ("20.00-25.00", 22.5, "nb:FromRange"),
     ],
 )
-def test_age_gets_converted(raw_age, expected_age, heuristic):
-    assert expected_age == pheno_utils.transform_age(raw_age, heuristic)
+def test_age_gets_converted(raw_age, expected_age, value_format):
+    assert expected_age == pheno_utils.transform_age(raw_age, value_format)
 
 
 @pytest.mark.parametrize(
-    "raw_age, incorrect_heuristic",
+    "raw_age, incorrect_format",
     [
         ("11,0", "nb:FromFloat"),
         ("11.0", "nb:FromISO8601"),
@@ -355,18 +355,18 @@ def test_age_gets_converted(raw_age, expected_age, heuristic):
         ("20+", "nb:FromRange"),
     ],
 )
-def test_incorrect_age_heuristic(raw_age, incorrect_heuristic):
+def test_incorrect_age_format(raw_age, incorrect_format):
     """Given an age transformation that does not match the type of age value provided, returns an informative error."""
     with pytest.raises(ValueError) as e:
-        pheno_utils.transform_age(raw_age, incorrect_heuristic)
+        pheno_utils.transform_age(raw_age, incorrect_format)
 
     assert (
-        f"problem with applying the age transformation: {incorrect_heuristic}."
+        f"problem with applying the age transformation: {incorrect_format}."
         in str(e.value)
     )
 
 
-def test_invalid_age_heuristic():
+def test_invalid_age_format():
     """Given an age transformation that is not recognized, returns an informative ValueError."""
     with pytest.raises(ValueError) as e:
         pheno_utils.transform_age("11,0", "nb:birthyear")

--- a/tests/unit/test_pheno_utils.py
+++ b/tests/unit/test_pheno_utils.py
@@ -339,6 +339,7 @@ def test_missing_ids_in_columns(test_data, columns, expected_indices):
         ("P20Y6M", 20.5, "nb:FromISO8601"),
         ("20Y9M", 20.75, "nb:FromISO8601"),
         ("20-25", 22.5, "nb:FromRange"),
+        ("20.5-25.5", 23.0, "nb:FromRange"),
     ],
 )
 def test_age_gets_converted(raw_age, expected_age, heuristic):


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the Neurobagel PR process and other contributing guidelines, see https://neurobagel.org/contributing/CONTRIBUTING/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #433 

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- Add transformation logic for age column annotated with `nb:FromRange`
- Link to Neurobagel docs in error message for info on acceptable values for transformations
- Replace "heuristic" with "format" across code
  - See also https://github.com/neurobagel/bagel-cli/issues/438

Housekeeping:
- Fix links for README badges

<!-- To be checked off by reviewers -->
## Checklist
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING#pull-request-guidelines) for more info)_
- [x] PR has a label for the release changelog or `skip-release` (to be applied by maintainers only)
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.

## Summary by Sourcery

Introduce support for ranged ages in the age transformation utility with the `nb:FromRange` heuristic and enhance error messaging for transformation failures. Add unit tests to ensure correct functionality of the new feature.

New Features:
- Add support for ranged ages using the `nb:FromRange` heuristic in the age transformation utility.

Enhancements:
- Improve error messages for age transformation failures by providing examples of acceptable values for specific age transformations.

Tests:
- Add unit tests to verify the correct conversion of ranged ages using the `nb:FromRange` heuristic.

## Summary by Sourcery

Adds support for ranged ages using the `nb:FromRange` heuristic in the age transformation utility. Also, improves error messages for age transformation failures by providing examples of acceptable values for specific age transformations, and fixes broken links in the README.

New Features:
- Add support for ranged ages using the `nb:FromRange` heuristic in the age transformation utility.

Tests:
- Adds unit tests to verify the correct conversion of ranged ages using the `nb:FromRange` heuristic.