### PR TITLE
Rename transformation to format

### DIFF
--- a/bagel/cli.py
+++ b/bagel/cli.py
@@ -53,6 +53,7 @@ def overwrite_option():
     )
 
 
+# TODO: Look into whitespace for command docstring - seems to be preserved in the help text.
 @bagel.command()
 def pheno(
     pheno: Path = typer.Option(  # TODO: Rename argument to something clearer, like --tabular.
@@ -125,6 +126,11 @@ def pheno(
     logger.info("%-*s%s", width, "Tabular file (.tsv):", pheno)
     logger.info("%-*s%s", width, "Data dictionary (.json):", dictionary)
     pheno_utils.validate_inputs(data_dictionary, pheno_df)
+
+    # TODO: Remove once we no longer support annotation tool v1 data dictionaries
+    data_dictionary = pheno_utils.convert_transformation_to_format(
+        data_dictionary
+    )
 
     logger.info("Processing phenotypic annotations...")
     subject_list = []

--- a/bagel/dictionary_models.py
+++ b/bagel/dictionary_models.py
@@ -1,6 +1,13 @@
-from typing import Dict, List, Union
+from typing import Any, Dict, List, Union
 
-from pydantic import AfterValidator, BaseModel, ConfigDict, Field, RootModel
+from pydantic import (
+    AfterValidator,
+    BaseModel,
+    ConfigDict,
+    Field,
+    RootModel,
+    model_validator,
+)
 from pydantic_core import PydanticCustomError
 from typing_extensions import Annotated
 
@@ -78,14 +85,26 @@ class CategoricalNeurobagel(Neurobagel):
 class ContinuousNeurobagel(Neurobagel):
     """A Neurobagel annotation for a continuous column"""
 
-    transformation: Identifier = Field(
+    format: Identifier = Field(
         ...,
-        description="For continuous columns this field can be used to describe"
-        "a transformation that can be applied to the values in this"
+        description="For continuous columns this field is used to describe"
+        "the numerical format of values, which is then used to transform this"
         "column in order to match the desired format of a standardized"
         "data element referenced in the IsAbout attribute.",
-        alias="Transformation",
+        alias="Format",
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def accept_format_or_transformation(cls, data: Any) -> Any:
+        """
+        Support data dictionaries annotated using the annotation tool v1 where "Format" was named "Transformation".
+        TODO: Remove when we no longer support the deprecated field name.
+        """
+        if isinstance(data, dict):
+            if "Format" not in data and "Transformation" in data:
+                data["Format"] = data["Transformation"]
+        return data
 
 
 class IdentifierNeurobagel(Neurobagel):

--- a/bagel/dictionary_models.py
+++ b/bagel/dictionary_models.py
@@ -75,7 +75,7 @@ class CategoricalNeurobagel(Neurobagel):
     levels: Dict[str, Identifier] = Field(
         ...,
         description="For categorical variables: "
-        "An object of values (keys) in the column and the semantic"
+        "An object of values (keys) in the column and the semantic "
         "term (URI and label) they are unambiguously mapped to.",
         alias="Levels",
     )
@@ -86,9 +86,9 @@ class ContinuousNeurobagel(Neurobagel):
 
     format: Identifier = Field(
         ...,
-        description="For continuous columns this field is used to describe"
-        "the numerical format of values, which is then used to transform this"
-        "column in order to match the desired format of a standardized"
+        description="For continuous columns this field is used to describe "
+        "the numerical format of values, which is then used to transform this "
+        "column in order to match the desired format of a standardized "
         "data element referenced in the IsAbout attribute.",
         alias="Format",
     )

--- a/bagel/dictionary_models.py
+++ b/bagel/dictionary_models.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Union
+from typing import Dict, List, Union
 
 from pydantic import (
     AfterValidator,
@@ -6,7 +6,6 @@ from pydantic import (
     ConfigDict,
     Field,
     RootModel,
-    model_validator,
 )
 from pydantic_core import PydanticCustomError
 from typing_extensions import Annotated
@@ -93,18 +92,6 @@ class ContinuousNeurobagel(Neurobagel):
         "data element referenced in the IsAbout attribute.",
         alias="Format",
     )
-
-    @model_validator(mode="before")
-    @classmethod
-    def accept_format_or_transformation(cls, data: Any) -> Any:
-        """
-        Support data dictionaries annotated using the annotation tool v1 where "Format" was named "Transformation".
-        TODO: Remove when we no longer support the deprecated field name.
-        """
-        if isinstance(data, dict):
-            if "Format" not in data and "Transformation" in data:
-                data["Format"] = data["Transformation"]
-        return data
 
 
 class IdentifierNeurobagel(Neurobagel):

--- a/bagel/utilities/pheno_utils.py
+++ b/bagel/utilities/pheno_utils.py
@@ -574,10 +574,15 @@ def convert_transformation_to_format(data_dict: dict) -> dict:
     )
     if age_column_names:
         # NOTE: At the moment, data dictionary validation only allows a single age column
-        age_annotations = data_dict[age_column_names[0]]["Annotations"]
-        if "Format" in age_annotations:
-            age_annotations.pop("Transformation", None)
-        elif "Transformation" in age_annotations:
+        age_column_name = age_column_names[0]
+        age_annotations = data_dict[age_column_name]["Annotations"]
+        if "Transformation" in age_annotations:
             age_annotations["Format"] = age_annotations.pop("Transformation")
+            logger.warning(
+                f"The data dictionary contains a deprecated 'Transformation' key in the annotations for the column: {age_column_name}. "
+                "This key has been renamed to 'Format'. For now, 'Transformation' will be interpreted as equivalent to 'Format', "
+                "but support for 'Transformation' will be removed in a future release. "
+                "We recommend updating your data dictionary using the latest version of the Neurobagel annotation tool."
+            )
 
     return data_dict

--- a/bagel/utilities/pheno_utils.py
+++ b/bagel/utilities/pheno_utils.py
@@ -216,16 +216,16 @@ def transform_age(value: str, value_format: str) -> float:
             return sum(map(float, [a_min, a_max])) / 2
         log_error(
             logger,
-            f"The provided data dictionary contains an unrecognized age transformation: {value_format}. "
-            f"Ensure that the transformation TermURL is one of {list(AGE_FORMATS.values())}.",
+            f"The provided data dictionary contains an unrecognized age format: {value_format}. "
+            f"Ensure that the format TermURL is one of {list(AGE_FORMATS.values())}.",
         )
     except (ValueError, isodate.isoerror.ISO8601Error) as e:
         log_error(
             logger,
-            f"There was a problem with applying the transformation {value_format} to the age: {value}. Error: {str(e)}\n"
-            f"Check that the transformation specified in the data dictionary ({value_format}) is correct for the age values in your phenotypic file, "
+            f"There was a problem with applying the format {value_format} to the age: {value}. Error: {str(e)}\n"
+            f"Check that the format specified in the data dictionary ({value_format}) is correct for the age values in your phenotypic file, "
             "and that you correctly annotated any missing values in your age column. "
-            "For examples of acceptable values for specific age transformations, see https://neurobagel.org/data_models/dictionaries/#age.",
+            "For examples of acceptable values for specific age formats, see https://neurobagel.org/data_models/dictionaries/#age.",
         )
 
 
@@ -563,9 +563,6 @@ def convert_transformation_to_format(data_dict: dict) -> dict:
     If the uploaded data dictionary contains a "Transformation" key, rename the key to "Format"
     internally for downstream operations involving the data dictionary.
     This ensures compatibility with both v1 and v2 annotation tool-generated data dictionaries.
-
-    If both "Format" and "Transformation" keys are present, the "Transformation" key is removed
-    (ignored) from the internal data dictionary representation to avoid potential conflicts.
 
     TODO: Remove when we no longer support data dictionaries annotated using annotation tool v1.
     """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,22 +20,25 @@ def disable_rich_markup(monkeypatch):
     monkeypatch.setattr(bagel, "rich_markup_mode", None)
 
 
+# TODO: Revisit these fixtures - it seems it's safer to explicitly define the logger name because the CLI uses a named logger ("bagel.logger").
+# When the logger name is unset, there can be weird behaviour where caplog will only capture logs from the root logger for certain test modules
+# (maybe due to import order?), depending on how pytest is run (e.g., on a specific test file or all tests).
 @pytest.fixture(scope="function")
 def propagate_warnings(caplog):
     """Only capture WARNING logs and above from the CLI."""
-    caplog.set_level(logging.WARNING)
+    caplog.set_level(logging.WARNING, logger="bagel.logger")
 
 
 @pytest.fixture(scope="function")
 def propagate_info(caplog):
     """Only capture INFO logs and above from the CLI."""
-    caplog.set_level(logging.INFO)
+    caplog.set_level(logging.INFO, logger="bagel.logger")
 
 
 @pytest.fixture(scope="function")
 def propagate_errors(caplog):
     """Only capture ERROR logs and above from the CLI."""
-    caplog.set_level(logging.ERROR)
+    caplog.set_level(logging.ERROR, logger="bagel.logger")
 
 
 @pytest.fixture(scope="session")

--- a/tests/data/example12.json
+++ b/tests/data/example12.json
@@ -68,7 +68,7 @@
         "TermURL": "nb:Age",
         "Label": "Chronological age"
       },
-      "Transformation": {
+      "Format": {
         "TermURL": "nb:FromISO8601",
         "Label": "A period of time defined according to the ISO8601 standard"
       }

--- a/tests/data/example13.json
+++ b/tests/data/example13.json
@@ -26,7 +26,7 @@
         "TermURL": "nb:Age",
         "Label": "Chronological age"
       },
-      "Transformation": {
+      "Format": {
         "TermURL": "nb:FromEuro",
         "Label": "writing the time with a comma - why not"
       },

--- a/tests/data/example14.json
+++ b/tests/data/example14.json
@@ -72,7 +72,7 @@
         "TermURL": "nb:Age",
         "Label": "Chronological age"
       },
-      "Transformation": {
+      "Format": {
         "TermURL": "nb:FromISO8601",
         "Label": "A period of time defined according to the ISO8601 standard"
       }

--- a/tests/data/example15.json
+++ b/tests/data/example15.json
@@ -65,7 +65,7 @@
         "TermURL": "nb:Age",
         "Label": "Chronological age"
       },
-      "Transformation": {
+      "Format": {
         "TermURL": "nb:FromISO8601",
         "Label": "A period of time defined according to the ISO8601 standard"
       }

--- a/tests/data/example16.json
+++ b/tests/data/example16.json
@@ -72,7 +72,7 @@
         "TermURL": "nb:Age",
         "Label": "Chronological age"
       },
-      "Transformation": {
+      "Format": {
         "TermURL": "nb:FromISO8601",
         "Label": "A period of time defined according to the ISO8601 standard"
       }

--- a/tests/data/example17.json
+++ b/tests/data/example17.json
@@ -62,7 +62,7 @@
         "TermURL": "nb:Age",
         "Label": "Chronological age"
       },
-      "Transformation": {
+      "Format": {
         "TermURL": "nb:FromISO8601",
         "Label": "A period of time defined according to the ISO8601 standard"
       }

--- a/tests/data/example18.json
+++ b/tests/data/example18.json
@@ -62,7 +62,7 @@
         "TermURL": "nb:Age",
         "Label": "Chronological age"
       },
-      "Transformation": {
+      "Format": {
         "TermURL": "nb:FromISO8601",
         "Label": "A period of time defined according to the ISO8601 standard"
       }

--- a/tests/data/example19.json
+++ b/tests/data/example19.json
@@ -100,7 +100,7 @@
         "TermURL": "nb:Age",
         "Label": "Chronological age"
       },
-      "Transformation": {
+      "Format": {
         "TermURL": "nb:FromISO8601",
         "Label": "A period of time defined according to the ISO8601 standard"
       }

--- a/tests/data/example2.json
+++ b/tests/data/example2.json
@@ -72,7 +72,7 @@
         "TermURL": "nb:Age",
         "Label": "Chronological age"
       },
-      "Transformation": {
+      "Format": {
         "TermURL": "nb:FromISO8601",
         "Label": "A period of time defined according to the ISO8601 standard"
       }

--- a/tests/data/example20.json
+++ b/tests/data/example20.json
@@ -123,7 +123,7 @@
         "TermURL": "nb:Age",
         "Label": "Chronological age"
       },
-      "Transformation": {
+      "Format": {
         "TermURL": "nb:FromISO8601",
         "Label": "A period of time defined according to the ISO8601 standard"
       }
@@ -136,7 +136,7 @@
         "TermURL": "nb:Age",
         "Label": "Chronological age"
       },
-      "Transformation": {
+      "Format": {
         "TermURL": "nb:FromFloat",
         "Label": "Age as a floating point number"
       }

--- a/tests/data/example21.json
+++ b/tests/data/example21.json
@@ -72,7 +72,7 @@
         "TermURL": "nb:Age",
         "Label": "Chronological age"
       },
-      "Transformation": {
+      "Format": {
         "TermURL": "nb:FromISO8601",
         "Label": "A period of time defined according to the ISO8601 standard"
       }

--- a/tests/data/example_iso88591.json
+++ b/tests/data/example_iso88591.json
@@ -26,7 +26,7 @@
         "TermURL": "nb:Age",
         "Label": "Chronological age"
       },
-      "Transformation": {
+      "Format": {
         "TermURL": "nb:FromISO8601",
         "Label": "A period of time defined according to the ISO8601 standard"
       }

--- a/tests/unit/test_pheno_utils.py
+++ b/tests/unit/test_pheno_utils.py
@@ -31,7 +31,7 @@ from bagel.utilities import pheno_utils
             },
             "sex",
         ),
-        # age column missing Transformation
+        # age column missing Format
         (
             {
                 "participant_id": {
@@ -56,6 +56,7 @@ from bagel.utilities import pheno_utils
             },
             "age",
         ),
+        # age column containing both Format and Transformation (invalid)
         (
             {
                 "participant_id": {
@@ -390,22 +391,22 @@ def test_age_gets_converted(raw_age, expected_age, value_format):
 def test_incorrect_age_format(
     raw_age, incorrect_format, caplog, propagate_errors
 ):
-    """Given an age transformation that does not match the type of age value provided, returns an informative error."""
+    """Given an age format that does not match the type of age value provided, returns an informative error."""
     with pytest.raises(typer.Exit):
         pheno_utils.transform_age(raw_age, incorrect_format)
 
     assert (
-        f"problem with applying the transformation {incorrect_format} to the age: {raw_age}"
+        f"problem with applying the format {incorrect_format} to the age: {raw_age}"
         in caplog.text
     )
 
 
 def test_invalid_age_format(caplog, propagate_errors):
-    """Given an age transformation that is not recognized, returns an informative ValueError."""
+    """Given an age format that is not recognized, returns an informative ValueError."""
     with pytest.raises(typer.Exit):
         pheno_utils.transform_age("11,0", "nb:birthyear")
 
-    assert "unrecognized age transformation: nb:birthyear" in caplog.text
+    assert "unrecognized age format: nb:birthyear" in caplog.text
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/test_pheno_utils.py
+++ b/tests/unit/test_pheno_utils.py
@@ -456,11 +456,49 @@ def test_invalid_age_format(caplog, propagate_errors):
                 },
             },
         },
+        {
+            "participant_id": {
+                "Description": "Participant ID",
+                "Annotations": {
+                    "IsAbout": {
+                        "TermURL": "nb:ParticipantID",
+                        "Label": "Unique participant identifier",
+                    },
+                    "Identifies": "participant",
+                },
+            },
+            "age_iso8601": {
+                "Description": "Participant age in ISO8601 format",
+                "Annotations": {
+                    "IsAbout": {"TermURL": "nb:Age", "Label": "Age"},
+                    "Transformation": {
+                        "TermURL": "nb:FromISO8601",
+                        "Label": "period of time defined according to the ISO8601 standard",
+                    },
+                },
+            },
+            "age": {
+                "Description": "Age in years",
+                "Annotations": {
+                    "IsAbout": {"TermURL": "nb:Age", "Label": "Age"},
+                    "Transformation": {
+                        "TermURL": "nb:FromFloat",
+                        "Label": "float value",
+                    },
+                },
+            },
+        },
     ],
 )
-def test_format_and_transformation_schema_validation(data_dict):
-    """A data dictionary with either a valid 'Format' or 'Transformation' field should pass schema validation."""
+def test_format_and_transformation_schema_validation(
+    data_dict, caplog, propagate_errors
+):
+    """
+    A data dictionary where continuous columns have either a valid 'Format' or 'Transformation' field
+    should pass validation without errors.
+    """
     pheno_utils.validate_data_dict(data_dict)
+    assert len(caplog.records) == 0
 
 
 @pytest.mark.parametrize(
@@ -560,16 +598,84 @@ def test_format_and_transformation_schema_validation(data_dict):
             },
             1,
         ),
+        (
+            {
+                "participant_id": {
+                    "Description": "Participant ID",
+                    "Annotations": {
+                        "IsAbout": {
+                            "TermURL": "nb:ParticipantID",
+                            "Label": "Unique participant identifier",
+                        },
+                        "Identifies": "participant",
+                    },
+                },
+                "age_iso8601": {
+                    "Description": "Participant age in ISO8601 format",
+                    "Annotations": {
+                        "IsAbout": {"TermURL": "nb:Age", "Label": "Age"},
+                        "Transformation": {
+                            "TermURL": "nb:FromISO8601",
+                            "Label": "period of time defined according to the ISO8601 standard",
+                        },
+                    },
+                },
+                "age": {
+                    "Description": "Age in years",
+                    "Annotations": {
+                        "IsAbout": {"TermURL": "nb:Age", "Label": "Age"},
+                        "Transformation": {
+                            "TermURL": "nb:FromFloat",
+                            "Label": "float value",
+                        },
+                    },
+                },
+            },
+            {
+                "participant_id": {
+                    "Description": "Participant ID",
+                    "Annotations": {
+                        "IsAbout": {
+                            "TermURL": "nb:ParticipantID",
+                            "Label": "Unique participant identifier",
+                        },
+                        "Identifies": "participant",
+                    },
+                },
+                "age_iso8601": {
+                    "Description": "Participant age in ISO8601 format",
+                    "Annotations": {
+                        "IsAbout": {"TermURL": "nb:Age", "Label": "Age"},
+                        "Format": {
+                            "TermURL": "nb:FromISO8601",
+                            "Label": "period of time defined according to the ISO8601 standard",
+                        },
+                    },
+                },
+                "age": {
+                    "Description": "Age in years",
+                    "Annotations": {
+                        "IsAbout": {"TermURL": "nb:Age", "Label": "Age"},
+                        "Format": {
+                            "TermURL": "nb:FromFloat",
+                            "Label": "float value",
+                        },
+                    },
+                },
+            },
+            1,
+        ),
     ],
 )
 def test_convert_transformation_to_format(
     raw_data_dict,
     expected_data_dict,
+    expected_warnings,
     caplog,
     propagate_warnings,
-    expected_warnings,
 ):
-    """If a 'Transformation' key is found in a data dictionary, it should be converted to 'Format' for downstream operations."""
+    """If any 'Transformation' keys are found in a data dictionary, they should be converted to 'Format' for downstream operations."""
+
     converted_data_dict = pheno_utils.convert_transformation_to_format(
         raw_data_dict
     )


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the Neurobagel PR process and other contributing guidelines, see https://neurobagel.org/contributing/CONTRIBUTING/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #438 

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- Rename `Transformation` field to `Format` in the data dictionary model for continuous columns
- For backwards compatibility with old data dictionaries, add logic to:
  - Patch the schema used for data dictionary jsonschema validation to accept either `Transformation` or `Format` in a column (without encoding this in the actual data dictionary model)
  - Internally convert instances of `Transformation` to `Format` for the purposes of graph data generation, with an informative deprecation warning
- Updated user-facing messages
- Update all test data JSONs to use `Format`

<!-- To be checked off by reviewers -->
## Checklist
_This section is for the PR reviewer_

- [ ] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING#pull-request-guidelines) for more info)_
- [ ] PR has a label for the release changelog or `skip-release` (to be applied by maintainers only)
- [ ] PR links to GitHub issue with mention `Closes #XXXX`
- [ ] Tests pass
- [ ] Checks pass

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.
