### PR TITLE
[ENH] Remove `"Identifies"` key and add `"VariableType"` key to data dictionary schema

### DIFF
--- a/bagel/cli.py
+++ b/bagel/cli.py
@@ -112,7 +112,7 @@ def bids2tsv(
     dataset_tab = b2t2.index_dataset(bids_dir)
     dataset_df = dataset_tab.to_pandas()
 
-    dataset_df = dataset_df.query('ext in [".nii", ".nii.gz"]')
+    dataset_df = dataset_df.query('ext in [".nii", ".nii.gz"]').copy()
     dataset_df["path"] = dataset_df.apply(
         lambda row: (Path(row["root"]) / row["path"]).as_posix(), axis=1
     )

--- a/bagel/dictionary_models.py
+++ b/bagel/dictionary_models.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Union
+from typing import Dict, List, Literal, Union
 
 from pydantic import (
     AfterValidator,
@@ -30,6 +30,7 @@ def validate_unique_list(values: List[str]) -> List[str]:
     return values
 
 
+# TODO: Rename "Identifier" to "Term" to avoid confusion with the IdentifierNeurobagel class?
 class Identifier(BaseModel):
     """An identifier of a controlled term with an IRI"""
 
@@ -77,8 +78,8 @@ class IdentifierNeurobagel(BaseModel):
         description="The concept or controlled term that describes this column",
         alias="IsAbout",
     )
+    variableType: Literal["Identifier"] = Field(..., alias="VariableType")
 
-    # We need to forbid extra fields to prevent partially annotated columns from being parsed as IdentifierNeurobagel
     model_config = ConfigDict(extra="forbid")
 
 
@@ -92,6 +93,7 @@ class CategoricalNeurobagel(Neurobagel):
         "term (URI and label) they are unambiguously mapped to.",
         alias="Levels",
     )
+    variableType: Literal["Categorical"] = Field(..., alias="VariableType")
 
 
 class ContinuousNeurobagel(Neurobagel):
@@ -105,6 +107,7 @@ class ContinuousNeurobagel(Neurobagel):
         "data element referenced in the IsAbout attribute.",
         alias="Format",
     )
+    variableType: Literal["Continuous"] = Field(..., alias="VariableType")
 
 
 class ToolNeurobagel(Neurobagel):
@@ -118,6 +121,7 @@ class ToolNeurobagel(Neurobagel):
         "then the assessment tool should be specified here.",
         alias="IsPartOf",
     )
+    variableType: Literal["Collection"] = Field(..., alias="VariableType")
 
 
 class Column(BaseModel):

--- a/bagel/dictionary_models.py
+++ b/bagel/dictionary_models.py
@@ -69,6 +69,19 @@ class Neurobagel(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
 
+class IdentifierNeurobagel(BaseModel):
+    """A Neurobagel annotation for an identifier column"""
+
+    isAbout: Identifier = Field(
+        ...,
+        description="The concept or controlled term that describes this column",
+        alias="IsAbout",
+    )
+
+    # We need to forbid extra fields to prevent partially annotated columns from being parsed as IdentifierNeurobagel
+    model_config = ConfigDict(extra="forbid")
+
+
 class CategoricalNeurobagel(Neurobagel):
     """A Neurobagel annotation for a categorical column"""
 
@@ -94,16 +107,6 @@ class ContinuousNeurobagel(Neurobagel):
     )
 
 
-class IdentifierNeurobagel(Neurobagel):
-    """A Neurobagel annotation for an identifier column"""
-
-    identifies: str = Field(
-        ...,
-        description="For identifier columns, the type of observation uniquely identified by this column.",
-        alias="Identifies",
-    )
-
-
 class ToolNeurobagel(Neurobagel):
     """A Neurobagel annotation for an assessment tool column"""
 
@@ -120,6 +123,9 @@ class ToolNeurobagel(Neurobagel):
 class Column(BaseModel):
     """The base model for a BIDS column description"""
 
+    # TODO: Revisit if we want to make description an optional field, since we don't currently use it in the graph data.
+    # At the moment, the key itself is always required and the value can be an empty string "",
+    # but a value of null ("Description": null) is invalid and will result in a schema validation error.
     description: str = Field(
         ...,
         description="Free-form natural language description",
@@ -149,7 +155,7 @@ class ContinuousColumn(Column):
     """A BIDS column annotation for a continuous column"""
 
     units: str = Field(
-        None,
+        ...,
         description="Measurement units for the values in this column. "
         "SI units in CMIXF formatting are RECOMMENDED (see Units)",
         alias="Units",
@@ -157,7 +163,7 @@ class ContinuousColumn(Column):
 
 
 class DataDictionary(
-    RootModel[Dict[str, Union[ContinuousColumn, CategoricalColumn]]]
+    RootModel[Dict[str, Union[Column, ContinuousColumn, CategoricalColumn]]]
 ):
     """A data dictionary with human and machine readable information for a tabular data file"""
 

--- a/bagel/utilities/pheno_utils.py
+++ b/bagel/utilities/pheno_utils.py
@@ -177,9 +177,15 @@ def is_missing_value(
 
 def is_column_categorical(column: str, data_dict: dict) -> bool:
     """Determine whether a column in a Neurobagel data dictionary is categorical"""
-    if "Levels" in data_dict[column]["Annotations"]:
+    column_annotation = data_dict[column]["Annotations"]
+
+    try:
+        dictionary_models.CategoricalNeurobagel.model_validate(
+            column_annotation
+        )
         return True
-    return False
+    except pydantic.ValidationError:
+        return False
 
 
 def map_cat_val_to_term(

--- a/tests/data/example1.json
+++ b/tests/data/example1.json
@@ -5,7 +5,8 @@
             "IsAbout": {
                 "TermURL": "nb:ParticipantID",
                 "Label": "Unique participant identifier"
-            }
+            },
+            "VariableType": "Identifier"
         }
     },
     "session_id": {
@@ -14,7 +15,8 @@
             "IsAbout": {
                 "TermURL": "nb:SessionID",
                 "Label": "Unique session identifier"
-            }
+            },
+            "VariableType": "Identifier"
         }
     },
     "group": {
@@ -28,6 +30,7 @@
                 "TermURL": "nb:Diagnosis",
                 "Label": "Diagnosis"
             },
+            "VariableType": "Categorical",
             "Levels": {
                 "PAT": {
                     "TermURL": "snomed:49049000",

--- a/tests/data/example1.json
+++ b/tests/data/example1.json
@@ -5,8 +5,7 @@
             "IsAbout": {
                 "TermURL": "nb:ParticipantID",
                 "Label": "Unique participant identifier"
-            },
-            "Identifies": "participant"
+            }
         }
     },
     "session_id": {
@@ -15,8 +14,7 @@
             "IsAbout": {
                 "TermURL": "nb:SessionID",
                 "Label": "Unique session identifier"
-            },
-            "Identifies": "session"
+            }
         }
     },
     "group": {

--- a/tests/data/example10.json
+++ b/tests/data/example10.json
@@ -5,7 +5,8 @@
             "IsAbout": {
                 "TermURL": "nb:ParticipantID",
                 "Label": "Unique participant identifier"
-            }
+            },
+            "VariableType": "Identifier"
         }
     },
     "session_id": {
@@ -14,7 +15,8 @@
             "IsAbout": {
                 "TermURL": "nb:SessionID",
                 "Label": "Unique session identifier"
-            }
+            },
+            "VariableType": "Identifier"
         }
     },
     "group": {
@@ -28,6 +30,7 @@
                 "TermURL": "nb:Diagnosis",
                 "Label": "Diagnosis"
             },
+            "VariableType": "Categorical",
             "Levels": {
                 "PAT": {
                     "TermURL": "snomed:49049000",
@@ -48,6 +51,7 @@
                 "TermURL": "nb:Assessment",
                 "Label": "Assessment tool"
             },
+            "VariableType": "Collection",
             "IsPartOf": {
                 "TermURL": "snomed:1234",
                 "Label": "Imaginary tool"
@@ -62,6 +66,7 @@
                 "TermURL": "nb:Assessment",
                 "Label": "Assessment tool"
             },
+            "VariableType": "Collection",
             "IsPartOf": {
                 "TermURL": "snomed:1234",
                 "Label": "Imaginary tool"
@@ -76,6 +81,7 @@
                 "TermURL": "nb:Assessment",
                 "Label": "Assessment tool"
             },
+            "VariableType": "Collection",
             "IsPartOf": {
                 "TermURL": "snomed:4321",
                 "Label": "A different imaginary tool"

--- a/tests/data/example10.json
+++ b/tests/data/example10.json
@@ -5,8 +5,7 @@
             "IsAbout": {
                 "TermURL": "nb:ParticipantID",
                 "Label": "Unique participant identifier"
-            },
-            "Identifies": "participant"
+            }
         }
     },
     "session_id": {
@@ -15,8 +14,7 @@
             "IsAbout": {
                 "TermURL": "nb:SessionID",
                 "Label": "Unique session identifier"
-            },
-            "Identifies": "session"
+            }
         }
     },
     "group": {

--- a/tests/data/example11.json
+++ b/tests/data/example11.json
@@ -5,7 +5,8 @@
             "IsAbout": {
                 "TermURL": "nb:ParticipantID",
                 "Label": "Unique participant identifier"
-            }
+            },
+            "VariableType": "Identifier"
         }
     },
     "session_id": {
@@ -14,7 +15,8 @@
             "IsAbout": {
                 "TermURL": "nb:SessionID",
                 "Label": "Unique session identifier"
-            }
+            },
+            "VariableType": "Identifier"
         }
     },
     "group": {
@@ -28,6 +30,7 @@
                 "TermURL": "nb:Diagnosis",
                 "Label": "Diagnosis"
             },
+            "VariableType": "Categorical",
             "Levels": {
                 "PAT": {
                     "TermURL": "snomed:49049000",
@@ -48,6 +51,7 @@
                 "TermURL": "nb:Assessment",
                 "Label": "Assessment tool"
             },
+            "VariableType": "Collection",
             "IsPartOf": {
                 "TermURL": "snomed:1234",
                 "Label": "Imaginary tool"
@@ -62,6 +66,7 @@
                 "TermURL": "nb:Assessment",
                 "Label": "Assessment tool"
             },
+            "VariableType": "Collection",
             "IsPartOf": {
                 "TermURL": "snomed:1234",
                 "Label": "Imaginary tool"
@@ -76,6 +81,7 @@
                 "TermURL": "nb:Assessment",
                 "Label": "Assessment tool"
             },
+            "VariableType": "Collection",
             "IsPartOf": {
                 "TermURL": "snomed:4321",
                 "Label": "A different imaginary tool"

--- a/tests/data/example11.json
+++ b/tests/data/example11.json
@@ -5,8 +5,7 @@
             "IsAbout": {
                 "TermURL": "nb:ParticipantID",
                 "Label": "Unique participant identifier"
-            },
-            "Identifies": "participant"
+            }
         }
     },
     "session_id": {
@@ -15,8 +14,7 @@
             "IsAbout": {
                 "TermURL": "nb:SessionID",
                 "Label": "Unique session identifier"
-            },
-            "Identifies": "session"
+            }
         }
     },
     "group": {

--- a/tests/data/example12.json
+++ b/tests/data/example12.json
@@ -5,8 +5,7 @@
       "IsAbout": {
         "TermURL": "nb:ParticipantID",
         "Label": "Unique participant identifier"
-      },
-      "Identifies": "participant"
+      }
     }
   },
   "session_id": {
@@ -15,8 +14,7 @@
       "IsAbout": {
         "TermURL": "nb:SessionID",
         "Label": "Unique session identifier"
-      },
-      "Identifies": "session"
+      }
     }
   },
   "group": {

--- a/tests/data/example12.json
+++ b/tests/data/example12.json
@@ -5,7 +5,8 @@
       "IsAbout": {
         "TermURL": "nb:ParticipantID",
         "Label": "Unique participant identifier"
-      }
+      },
+      "VariableType": "Identifier"
     }
   },
   "session_id": {
@@ -14,7 +15,8 @@
       "IsAbout": {
         "TermURL": "nb:SessionID",
         "Label": "Unique session identifier"
-      }
+      },
+      "VariableType": "Identifier"
     }
   },
   "group": {
@@ -24,6 +26,7 @@
         "TermURL": "nb:Diagnosis",
         "Label": "Diagnosis"
       },
+      "VariableType": "Categorical",
       "Levels": {
         "PAT": {
           "TermURL": "snomed:49049000",
@@ -47,6 +50,7 @@
         "TermURL": "nb:Sex",
         "Label": "Sex"
       },
+      "VariableType": "Categorical",
       "Levels": {
         "M": {
           "TermURL": "snomed:248153007",
@@ -66,6 +70,7 @@
         "TermURL": "nb:Age",
         "Label": "Chronological age"
       },
+      "VariableType": "Continuous",
       "Format": {
         "TermURL": "nb:FromISO8601",
         "Label": "A period of time defined according to the ISO8601 standard"

--- a/tests/data/example13.json
+++ b/tests/data/example13.json
@@ -5,7 +5,8 @@
             "IsAbout": {
                 "TermURL": "nb:ParticipantID",
                 "Label": "Unique participant identifier"
-            }
+            },
+            "VariableType": "Identifier"
         }
     },
     "session_id": {
@@ -14,48 +15,51 @@
             "IsAbout": {
                 "TermURL": "nb:SessionID",
                 "Label": "Unique session identifier"
-            }
+            },
+            "VariableType": "Identifier"
         }
     },
-      "pheno_age": {
-    "Description": "Age of the participant",
-    "Annotations": {
-      "IsAbout": {
-        "TermURL": "nb:Age",
-        "Label": "Chronological age"
-      },
-      "Format": {
-        "TermURL": "nb:FromEuro",
-        "Label": "writing the time with a comma - why not"
-      },
-      "MissingValues": ["NA"]
-    }
-  },
+    "pheno_age": {
+        "Description": "Age of the participant",
+        "Annotations": {
+            "IsAbout": {
+                "TermURL": "nb:Age",
+                "Label": "Chronological age"
+            },
+            "VariableType": "Continuous",
+            "Format": {
+                "TermURL": "nb:FromEuro",
+                "Label": "writing the time with a comma - why not"
+            },
+        "MissingValues": ["NA"]
+        }
+    },
     "pheno_sex": {
-    "Description": "Sex variable",
-    "Levels": {
-      "M": "Male",
-      "F": "Female",
-      "missing": "Missing sex",
-      "O": "Other unimportant level"
-    },
-    "Annotations": {
-      "IsAbout": {
-        "TermURL": "nb:Sex",
-        "Label": "Sex"
-      },
-      "Levels": {
-        "M": {
-          "TermURL": "snomed:248153007",
-          "Label": "Male"
+        "Description": "Sex variable",
+        "Levels": {
+            "M": "Male",
+            "F": "Female",
+            "missing": "Missing sex",
+            "O": "Other unimportant level"
         },
-        "F": {
-          "TermURL": "snomed:248152002",
-          "Label": "Female"
+        "Annotations": {
+            "IsAbout": {
+                "TermURL": "nb:Sex",
+                "Label": "Sex"
+            },
+            "VariableType": "Categorical",
+            "Levels": {
+                "M": {
+                    "TermURL": "snomed:248153007",
+                    "Label": "Male"
+                },
+                "F": {
+                    "TermURL": "snomed:248152002",
+                    "Label": "Female"
+                }
+            },
+            "MissingValues": ["missing"]
         }
-      },
-      "MissingValues": ["missing"]
-    }
   },
 
     "pheno_group": {
@@ -70,6 +74,7 @@
                 "TermURL": "nb:Diagnosis",
                 "Label": "Diagnosis"
             },
+            "VariableType": "Categorical",
             "Levels": {
                 "PAT": {
                     "TermURL": "snomed:49049000",
@@ -90,6 +95,7 @@
                 "TermURL": "nb:Assessment",
                 "Label": "Assessment tool"
             },
+            "VariableType": "Collection",
             "IsPartOf": {
                 "TermURL": "snomed:1234",
                 "Label": "Imaginary tool"
@@ -104,6 +110,7 @@
                 "TermURL": "nb:Assessment",
                 "Label": "Assessment tool"
             },
+            "VariableType": "Collection",
             "IsPartOf": {
                 "TermURL": "snomed:1234",
                 "Label": "Imaginary tool"
@@ -118,6 +125,7 @@
                 "TermURL": "nb:Assessment",
                 "Label": "Assessment tool"
             },
+            "VariableType": "Collection",
             "IsPartOf": {
                 "TermURL": "snomed:4321",
                 "Label": "A different imaginary tool"

--- a/tests/data/example13.json
+++ b/tests/data/example13.json
@@ -5,8 +5,7 @@
             "IsAbout": {
                 "TermURL": "nb:ParticipantID",
                 "Label": "Unique participant identifier"
-            },
-            "Identifies": "participant"
+            }
         }
     },
     "session_id": {
@@ -15,8 +14,7 @@
             "IsAbout": {
                 "TermURL": "nb:SessionID",
                 "Label": "Unique session identifier"
-            },
-            "Identifies": "session"
+            }
         }
     },
       "pheno_age": {

--- a/tests/data/example14.json
+++ b/tests/data/example14.json
@@ -5,8 +5,7 @@
       "IsAbout": {
         "TermURL": "nb:ParticipantID",
         "Label": "Unique participant identifier"
-      },
-      "Identifies": "participant"
+      }
     }
   },
   "session_id": {
@@ -15,8 +14,7 @@
       "IsAbout": {
         "TermURL": "nb:SessionID",
         "Label": "Unique session identifier"
-      },
-      "Identifies": "session"
+      }
     }
   },
   "group": {

--- a/tests/data/example14.json
+++ b/tests/data/example14.json
@@ -5,7 +5,8 @@
       "IsAbout": {
         "TermURL": "nb:ParticipantID",
         "Label": "Unique participant identifier"
-      }
+      },
+      "VariableType": "Identifier"
     }
   },
   "session_id": {
@@ -14,7 +15,8 @@
       "IsAbout": {
         "TermURL": "nb:SessionID",
         "Label": "Unique session identifier"
-      }
+      },
+      "VariableType": "Identifier"
     }
   },
   "group": {
@@ -28,6 +30,7 @@
         "TermURL": "nb:Diagnosis",
         "Label": "Diagnosis"
       },
+      "VariableType": "Categorical",
       "Levels": {
         "PAT": {
           "TermURL": "snomed:49049000",
@@ -51,6 +54,7 @@
         "TermURL": "nb:Sex",
         "Label": "Sex"
       },
+      "VariableType": "Categorical",
       "Levels": {
         "M": {
           "TermURL": "snomed:248153007",
@@ -70,6 +74,7 @@
         "TermURL": "nb:Age",
         "Label": "Chronological age"
       },
+      "VariableType": "Continuous",
       "Format": {
         "TermURL": "nb:FromISO8601",
         "Label": "A period of time defined according to the ISO8601 standard"

--- a/tests/data/example15.json
+++ b/tests/data/example15.json
@@ -8,7 +8,8 @@
       "IsAbout": {
         "TermURL": "nb:SessionID",
         "Label": "Unique session identifier"
-      }
+      },
+      "VariableType": "Identifier"
     }
   },
   "group": {
@@ -22,6 +23,7 @@
         "TermURL": "nb:Diagnosis",
         "Label": "Diagnosis"
       },
+      "VariableType": "Categorical",
       "Levels": {
         "PAT": {
           "TermURL": "snomed:49049000",
@@ -45,6 +47,7 @@
         "TermURL": "nb:Sex",
         "Label": "Sex"
       },
+      "VariableType": "Categorical",
       "Levels": {
         "M": {
           "TermURL": "snomed:248153007",
@@ -64,6 +67,7 @@
         "TermURL": "nb:Age",
         "Label": "Chronological age"
       },
+      "VariableType": "Continuous",
       "Format": {
         "TermURL": "nb:FromISO8601",
         "Label": "A period of time defined according to the ISO8601 standard"

--- a/tests/data/example15.json
+++ b/tests/data/example15.json
@@ -8,8 +8,7 @@
       "IsAbout": {
         "TermURL": "nb:SessionID",
         "Label": "Unique session identifier"
-      },
-      "Identifies": "session"
+      }
     }
   },
   "group": {

--- a/tests/data/example16.json
+++ b/tests/data/example16.json
@@ -5,8 +5,7 @@
       "IsAbout": {
         "TermURL": "nb:ParticipantID",
         "Label": "Unique participant identifier"
-      },
-      "Identifies": "participant"
+      }
     }
   },
   "session_id": {
@@ -15,8 +14,7 @@
       "IsAbout": {
         "TermURL": "nb:SessionID",
         "Label": "Unique session identifier"
-      },
-      "Identifies": "session"
+      }
     }
   },
   "group": {

--- a/tests/data/example16.json
+++ b/tests/data/example16.json
@@ -5,7 +5,8 @@
       "IsAbout": {
         "TermURL": "nb:ParticipantID",
         "Label": "Unique participant identifier"
-      }
+      },
+      "VariableType": "Identifier"
     }
   },
   "session_id": {
@@ -14,7 +15,8 @@
       "IsAbout": {
         "TermURL": "nb:SessionID",
         "Label": "Unique session identifier"
-      }
+      },
+      "VariableType": "Identifier"
     }
   },
   "group": {
@@ -28,6 +30,7 @@
         "TermURL": "nb:Diagnosis",
         "Label": "Diagnosis"
       },
+      "VariableType": "Categorical",
       "Levels": {
         "PAT": {
           "TermURL": "snomed:49049000",
@@ -51,6 +54,7 @@
         "TermURL": "nb:Sex",
         "Label": "Sex"
       },
+      "VariableType": "Categorical",
       "Levels": {
         "M": {
           "TermURL": "snomed:248153007",
@@ -70,6 +74,7 @@
         "TermURL": "nb:Age",
         "Label": "Chronological age"
       },
+      "VariableType": "Continuous",
       "Format": {
         "TermURL": "nb:FromISO8601",
         "Label": "A period of time defined according to the ISO8601 standard"

--- a/tests/data/example17.json
+++ b/tests/data/example17.json
@@ -5,8 +5,7 @@
       "IsAbout": {
         "TermURL": "nb:ParticipantID",
         "Label": "Unique participant identifier"
-      },
-      "Identifies": "participant"
+      }
     }
   },
   "group": {

--- a/tests/data/example17.json
+++ b/tests/data/example17.json
@@ -5,7 +5,8 @@
       "IsAbout": {
         "TermURL": "nb:ParticipantID",
         "Label": "Unique participant identifier"
-      }
+      },
+      "VariableType": "Identifier"
     }
   },
   "group": {
@@ -19,6 +20,7 @@
         "TermURL": "nb:Diagnosis",
         "Label": "Diagnosis"
       },
+      "VariableType": "Categorical",
       "Levels": {
         "PAT": {
           "TermURL": "snomed:49049000",
@@ -42,6 +44,7 @@
         "TermURL": "nb:Sex",
         "Label": "Sex"
       },
+      "VariableType": "Categorical",
       "Levels": {
         "M": {
           "TermURL": "snomed:248153007",
@@ -61,6 +64,7 @@
         "TermURL": "nb:Age",
         "Label": "Chronological age"
       },
+      "VariableType": "Continuous",
       "Format": {
         "TermURL": "nb:FromISO8601",
         "Label": "A period of time defined according to the ISO8601 standard"

--- a/tests/data/example18.json
+++ b/tests/data/example18.json
@@ -5,8 +5,7 @@
       "IsAbout": {
         "TermURL": "nb:ParticipantID",
         "Label": "Unique participant identifier"
-      },
-      "Identifies": "participant"
+      }
     }
   },
   "group": {

--- a/tests/data/example18.json
+++ b/tests/data/example18.json
@@ -5,7 +5,8 @@
       "IsAbout": {
         "TermURL": "nb:ParticipantID",
         "Label": "Unique participant identifier"
-      }
+      },
+      "VariableType": "Identifier"
     }
   },
   "group": {
@@ -28,7 +29,8 @@
           "TermURL": "ncit:C94342",
           "Label": "Healthy Control"
         }
-      }
+      },
+      "VariableType": "Categorical"
     }
   },
   "sex": {
@@ -51,7 +53,8 @@
           "TermURL": "snomed:248152002",
           "Label": "Female"
         }
-      }
+      },
+      "VariableType": "Categorical"
     }
   },
   "participant_age": {
@@ -64,7 +67,8 @@
       "Format": {
         "TermURL": "nb:FromISO8601",
         "Label": "A period of time defined according to the ISO8601 standard"
-      }
+      },
+      "VariableType": "Continuous"
     }
   }
 }

--- a/tests/data/example19.json
+++ b/tests/data/example19.json
@@ -5,8 +5,7 @@
       "IsAbout": {
         "TermURL": "nb:ParticipantID",
         "Label": "Unique participant identifier"
-      },
-      "Identifies": "participant"
+      }
     }
   },
   "session_id": {
@@ -15,8 +14,7 @@
       "IsAbout": {
         "TermURL": "nb:SessionID",
         "Label": "Unique session identifier"
-      },
-      "Identifies": "session"
+      }
     }
   },
   "group": {

--- a/tests/data/example19.json
+++ b/tests/data/example19.json
@@ -5,7 +5,8 @@
       "IsAbout": {
         "TermURL": "nb:ParticipantID",
         "Label": "Unique participant identifier"
-      }
+      },
+      "VariableType": "Identifier"
     }
   },
   "session_id": {
@@ -14,7 +15,8 @@
       "IsAbout": {
         "TermURL": "nb:SessionID",
         "Label": "Unique session identifier"
-      }
+      },
+      "VariableType": "Identifier"
     }
   },
   "group": {
@@ -37,7 +39,8 @@
           "TermURL": "ncit:C94342",
           "Label": "Healthy Control"
         }
-      }
+      },
+      "VariableType": "Categorical"
     }
   },
   "diagnosis": {
@@ -65,7 +68,8 @@
           "Label": "Alzheimer's disease"
         }
       },
-      "MissingValues": [""]
+      "MissingValues": [""],
+      "VariableType": "Categorical"
     }
   },
   "sex": {
@@ -88,7 +92,8 @@
           "TermURL": "snomed:248152002",
           "Label": "Female"
         }
-      }
+      },
+      "VariableType": "Categorical"
     }
   },
   "participant_age": {
@@ -101,7 +106,8 @@
       "Format": {
         "TermURL": "nb:FromISO8601",
         "Label": "A period of time defined according to the ISO8601 standard"
-      }
+      },
+      "VariableType": "Continuous"
     }
   }
 }

--- a/tests/data/example19.json
+++ b/tests/data/example19.json
@@ -61,7 +61,8 @@
           "Label": "Generalized anxiety disorder"
         }
       },
-      "MissingValues": [""]
+      "MissingValues": [""],
+      "VariableType": "Categorical"
     }
   },
   "secondary_diag": {

--- a/tests/data/example2.json
+++ b/tests/data/example2.json
@@ -5,8 +5,7 @@
       "IsAbout": {
         "TermURL": "nb:ParticipantID",
         "Label": "Unique participant identifier"
-      },
-      "Identifies": "participant"
+      }
     }
   },
   "session_id": {
@@ -15,8 +14,7 @@
       "IsAbout": {
         "TermURL": "nb:SessionID",
         "Label": "Unique session identifier"
-      },
-      "Identifies": "session"
+      }
     }
   },
   "group": {

--- a/tests/data/example2.json
+++ b/tests/data/example2.json
@@ -5,7 +5,8 @@
       "IsAbout": {
         "TermURL": "nb:ParticipantID",
         "Label": "Unique participant identifier"
-      }
+      },
+      "VariableType": "Identifier"
     }
   },
   "session_id": {
@@ -14,7 +15,8 @@
       "IsAbout": {
         "TermURL": "nb:SessionID",
         "Label": "Unique session identifier"
-      }
+      },
+      "VariableType": "Identifier"
     }
   },
   "group": {
@@ -28,6 +30,7 @@
         "TermURL": "nb:Diagnosis",
         "Label": "Diagnosis"
       },
+      "VariableType": "Categorical",
       "Levels": {
         "PAT": {
           "TermURL": "snomed:49049000",
@@ -51,6 +54,7 @@
         "TermURL": "nb:Sex",
         "Label": "Sex"
       },
+      "VariableType": "Categorical",
       "Levels": {
         "M": {
           "TermURL": "snomed:248153007",
@@ -70,6 +74,7 @@
         "TermURL": "nb:Age",
         "Label": "Chronological age"
       },
+      "VariableType": "Continuous",
       "Format": {
         "TermURL": "nb:FromISO8601",
         "Label": "A period of time defined according to the ISO8601 standard"

--- a/tests/data/example20.json
+++ b/tests/data/example20.json
@@ -5,8 +5,7 @@
       "IsAbout": {
         "TermURL": "nb:ParticipantID",
         "Label": "Unique participant identifier"
-      },
-      "Identifies": "participant"
+      }
     }
   },
   "session_id": {
@@ -15,8 +14,7 @@
       "IsAbout": {
         "TermURL": "nb:SessionID",
         "Label": "Unique session identifier"
-      },
-      "Identifies": "session"
+      }
     }
   },
   "group": {

--- a/tests/data/example20.json
+++ b/tests/data/example20.json
@@ -5,7 +5,8 @@
       "IsAbout": {
         "TermURL": "nb:ParticipantID",
         "Label": "Unique participant identifier"
-      }
+      },
+      "VariableType": "Identifier"
     }
   },
   "session_id": {
@@ -14,7 +15,8 @@
       "IsAbout": {
         "TermURL": "nb:SessionID",
         "Label": "Unique session identifier"
-      }
+      },
+      "VariableType": "Identifier"
     }
   },
   "group": {
@@ -37,7 +39,8 @@
           "TermURL": "ncit:C94342",
           "Label": "Healthy Control"
         }
-      }
+      },
+      "VariableType": "Categorical"
     }
   },
   "diagnosis": {
@@ -65,7 +68,8 @@
           "Label": "Alzheimer's disease"
         }
       },
-      "MissingValues": [""]
+      "MissingValues": [""],
+      "VariableType": "Categorical"
     }
   },
   "sex": {
@@ -88,7 +92,8 @@
           "TermURL": "snomed:248152002",
           "Label": "Female"
         }
-      }
+      },
+      "VariableType": "Categorical"
     }
   },
   "sex_full": {
@@ -111,7 +116,8 @@
           "TermURL": "snomed:248152002",
           "Label": "Female"
         }
-      }
+      },
+      "VariableType": "Categorical"
     }
   },
   "participant_age": {
@@ -124,7 +130,8 @@
       "Format": {
         "TermURL": "nb:FromISO8601",
         "Label": "A period of time defined according to the ISO8601 standard"
-      }
+      },
+      "VariableType": "Continuous"
     }
   },
   "participant_age_float": {
@@ -137,7 +144,8 @@
       "Format": {
         "TermURL": "nb:FromFloat",
         "Label": "Age as a floating point number"
-      }
+      },
+      "VariableType": "Continuous"
     }
   }
 }

--- a/tests/data/example21.json
+++ b/tests/data/example21.json
@@ -5,8 +5,7 @@
       "IsAbout": {
         "TermURL": "nb:ParticipantID",
         "Label": "Unique participant identifier"
-      },
-      "Identifies": "participant"
+      }
     }
   },
   "session_id": {
@@ -15,8 +14,7 @@
       "IsAbout": {
         "TermURL": "nb:SessionID",
         "Label": "Unique session identifier"
-      },
-      "Identifies": "session"
+      }
     }
   },
   "group": {

--- a/tests/data/example21.json
+++ b/tests/data/example21.json
@@ -5,7 +5,8 @@
       "IsAbout": {
         "TermURL": "nb:ParticipantID",
         "Label": "Unique participant identifier"
-      }
+      },
+      "VariableType": "Identifier"
     }
   },
   "session_id": {
@@ -14,7 +15,8 @@
       "IsAbout": {
         "TermURL": "nb:SessionID",
         "Label": "Unique session identifier"
-      }
+      },
+      "VariableType": "Identifier"
     }
   },
   "group": {
@@ -37,7 +39,8 @@
           "TermURL": "ncit:C94342",
           "Label": "Healthy Control"
         }
-      }
+      },
+      "VariableType": "Categorical"
     }
   },
   "sex": {
@@ -60,7 +63,8 @@
           "TermURL": "snomed:248152002",
           "Label": "Female"
         }
-      }
+      },
+      "VariableType": "Categorical"
     }
   },
   "participant_age": {
@@ -73,7 +77,8 @@
       "Format": {
         "TermURL": "nb:FromISO8601",
         "Label": "A period of time defined according to the ISO8601 standard"
-      }
+      },
+      "VariableType": "Continuous"
     }
   }
 }

--- a/tests/data/example4.json
+++ b/tests/data/example4.json
@@ -5,7 +5,8 @@
             "IsAbout": {
                 "TermURL": "nb:ParticipantID",
                 "Label": "Unique participant identifier"
-            }
+            },
+            "VariableType": "Identifier"
         }
     },
     "session_id": {
@@ -14,7 +15,8 @@
             "IsAbout": {
                 "TermURL": "nb:SessionID",
                 "Label": "Unique session identifier"
-            }
+            },
+            "VariableType": "Identifier"
         }
     },
     "group": {
@@ -28,6 +30,7 @@
                 "TermURL": "nb:Diagnosis",
                 "Label": "Diagnosis"
             },
+            "VariableType": "Categorical",
             "Levels": {
                 "PAT": {
                     "TermURL": "snomed:49049000",

--- a/tests/data/example4.json
+++ b/tests/data/example4.json
@@ -5,8 +5,7 @@
             "IsAbout": {
                 "TermURL": "nb:ParticipantID",
                 "Label": "Unique participant identifier"
-            },
-            "Identifies": "participant"
+            }
         }
     },
     "session_id": {
@@ -15,8 +14,7 @@
             "IsAbout": {
                 "TermURL": "nb:SessionID",
                 "Label": "Unique session identifier"
-            },
-            "Identifies": "session"
+            }
         }
     },
     "group": {

--- a/tests/data/example5.json
+++ b/tests/data/example5.json
@@ -5,7 +5,8 @@
             "IsAbout": {
                 "TermURL": "nb:ParticipantID",
                 "Label": "Unique participant identifier"
-            }
+            },
+            "VariableType": "Identifier"
         }
     },
     "session_id": {
@@ -14,7 +15,8 @@
             "IsAbout": {
                 "TermURL": "nb:SessionID",
                 "Label": "Unique session identifier"
-            }
+            },
+            "VariableType": "Identifier"
         }
     },
     "group": {
@@ -28,6 +30,7 @@
                 "TermURL": "nb:Diagnosis",
                 "Label": "Diagnosis"
             },
+            "VariableType": "Categorical",
             "Levels": {
                 "PAT": {
                     "TermURL": "snomed:49049000",
@@ -48,6 +51,7 @@
                 "TermURL": "nb:Assessment",
                 "Label": "Assessment tool"
             },
+            "VariableType": "Collection",
             "IsPartOf": {
                 "TermURL": "unknownvocab:1234",
                 "Label": "Imaginary tool"
@@ -62,6 +66,7 @@
                 "TermURL": "nb:Assessment",
                 "Label": "Assessment tool"
             },
+            "VariableType": "Collection",
             "IsPartOf": {
                 "TermURL": "unknownvocab:1234",
                 "Label": "Imaginary tool"
@@ -76,6 +81,7 @@
                 "TermURL": "nb:Assessment",
                 "Label": "Assessment tool"
             },
+            "VariableType": "Collection",
             "IsPartOf": {
                 "TermURL": "cogatlas:4321",
                 "Label": "A different imaginary tool"

--- a/tests/data/example5.json
+++ b/tests/data/example5.json
@@ -5,8 +5,7 @@
             "IsAbout": {
                 "TermURL": "nb:ParticipantID",
                 "Label": "Unique participant identifier"
-            },
-            "Identifies": "participant"
+            }
         }
     },
     "session_id": {
@@ -15,8 +14,7 @@
             "IsAbout": {
                 "TermURL": "nb:SessionID",
                 "Label": "Unique session identifier"
-            },
-            "Identifies": "session"
+            }
         }
     },
     "group": {

--- a/tests/data/example6.json
+++ b/tests/data/example6.json
@@ -57,7 +57,8 @@
                     "Label": "Healthy control"
                 }
             },
-            "MissingValues": ["false"]
+            "MissingValues": ["false"],
+            "VariableType": "Categorical"
         }
     },
     "tool_item1": {

--- a/tests/data/example6.json
+++ b/tests/data/example6.json
@@ -5,7 +5,8 @@
             "IsAbout": {
                 "TermURL": "nb:ParticipantID",
                 "Label": "Unique participant identifier"
-            }
+            },
+            "VariableType": "Identifier"
         }
     },
     "session_id": {
@@ -14,7 +15,8 @@
             "IsAbout": {
                 "TermURL": "nb:SessionID",
                 "Label": "Unique session identifier"
-            }
+            },
+            "VariableType": "Identifier"
         }
     },
     "group": {
@@ -28,6 +30,7 @@
                 "TermURL": "nb:Diagnosis",
                 "Label": "Diagnosis"
             },
+            "VariableType": "Categorical",
             "Levels": {
                 "PAT": {
                     "TermURL": "snomed:49049000",
@@ -48,6 +51,7 @@
                 "TermURL": "nb:Assessment",
                 "Label": "Assessment tool"
             },
+            "VariableType": "Collection",
             "IsPartOf": {
                 "TermURL": "snomed:1234",
                 "Label": "Imaginary tool"
@@ -62,6 +66,7 @@
                 "TermURL": "nb:Assessment",
                 "Label": "Assessment tool"
             },
+            "VariableType": "Collection",
             "IsPartOf": {
                 "TermURL": "snomed:1234",
                 "Label": "Imaginary tool"
@@ -76,6 +81,7 @@
                 "TermURL": "nb:Assessment",
                 "Label": "Assessment tool"
             },
+            "VariableType": "Collection",
             "IsPartOf": {
                 "TermURL": "snomed:4321",
                 "Label": "A different imaginary tool"

--- a/tests/data/example6.json
+++ b/tests/data/example6.json
@@ -5,8 +5,7 @@
             "IsAbout": {
                 "TermURL": "nb:ParticipantID",
                 "Label": "Unique participant identifier"
-            },
-            "Identifies": "participant"
+            }
         }
     },
     "session_id": {
@@ -15,8 +14,7 @@
             "IsAbout": {
                 "TermURL": "nb:SessionID",
                 "Label": "Unique session identifier"
-            },
-            "Identifies": "session"
+            }
         }
     },
     "group": {

--- a/tests/data/example7.json
+++ b/tests/data/example7.json
@@ -5,7 +5,8 @@
             "IsAbout": {
                 "TermURL": "nb:ParticipantID",
                 "Label": "Unique participant identifier"
-            }
+            },
+            "VariableType": "Identifier"
         }
     },
     "session_id": {
@@ -14,7 +15,8 @@
             "IsAbout": {
                 "TermURL": "nb:SessionID",
                 "Label": "Unique session identifier"
-            }
+            },
+            "VariableType": "Identifier"
         }
     },
     "group": {
@@ -28,6 +30,7 @@
                 "TermURL": "nb:Diagnosis",
                 "Label": "Diagnosis"
             },
+            "VariableType": "Categorical",
             "Levels": {
                 "PAT": {
                     "TermURL": "snomed:49049000",

--- a/tests/data/example7.json
+++ b/tests/data/example7.json
@@ -5,8 +5,7 @@
             "IsAbout": {
                 "TermURL": "nb:ParticipantID",
                 "Label": "Unique participant identifier"
-            },
-            "Identifies": "participant"
+            }
         }
     },
     "session_id": {
@@ -15,8 +14,7 @@
             "IsAbout": {
                 "TermURL": "nb:SessionID",
                 "Label": "Unique session identifier"
-            },
-            "Identifies": "session"
+            }
         }
     },
     "group": {

--- a/tests/data/example8.json
+++ b/tests/data/example8.json
@@ -5,8 +5,7 @@
             "IsAbout": {
                 "TermURL": "nb:ParticipantID",
                 "Label": "Unique participant identifier"
-            },
-            "Identifies": "participant"
+            }
         }
     },
     "alt_participant_id": {
@@ -15,8 +14,7 @@
             "IsAbout": {
                 "TermURL": "nb:ParticipantID",
                 "Label": "Unique participant identifier"
-            },
-            "Identifies": "participant"
+            }
         }
     },
     "session_id": {
@@ -25,8 +23,7 @@
             "IsAbout": {
                 "TermURL": "nb:SessionID",
                 "Label": "Unique session identifier"
-            },
-            "Identifies": "session"
+            }
         }
     },
     "group": {

--- a/tests/data/example8.json
+++ b/tests/data/example8.json
@@ -5,7 +5,8 @@
             "IsAbout": {
                 "TermURL": "nb:ParticipantID",
                 "Label": "Unique participant identifier"
-            }
+            },
+            "VariableType": "Identifier"
         }
     },
     "alt_participant_id": {
@@ -14,7 +15,8 @@
             "IsAbout": {
                 "TermURL": "nb:ParticipantID",
                 "Label": "Unique participant identifier"
-            }
+            },
+            "VariableType": "Identifier"
         }
     },
     "session_id": {
@@ -23,7 +25,8 @@
             "IsAbout": {
                 "TermURL": "nb:SessionID",
                 "Label": "Unique session identifier"
-            }
+            },
+            "VariableType": "Identifier"
         }
     },
     "group": {
@@ -37,6 +40,7 @@
                 "TermURL": "nb:Diagnosis",
                 "Label": "Diagnosis"
             },
+            "VariableType": "Categorical",
             "Levels": {
                 "PAT": {
                     "TermURL": "snomed:49049000",

--- a/tests/data/example9.json
+++ b/tests/data/example9.json
@@ -5,7 +5,8 @@
             "IsAbout": {
                 "TermURL": "nb:ParticipantID",
                 "Label": "Unique participant identifier"
-            }
+            },
+            "VariableType": "Identifier"
         }
     },
     "session_id": {
@@ -14,7 +15,8 @@
             "IsAbout": {
                 "TermURL": "nb:SessionID",
                 "Label": "Unique session identifier"
-            }
+            },
+            "VariableType": "Identifier"
         }
     },
     "group": {
@@ -28,6 +30,7 @@
                 "TermURL": "nb:Diagnosis",
                 "Label": "Diagnosis"
             },
+            "VariableType": "Categorical",
             "Levels": {
                 "PAT": {
                     "TermURL": "snomed:49049000",
@@ -48,6 +51,7 @@
                 "TermURL": "nb:Assessment",
                 "Label": "Assessment tool"
             },
+            "VariableType": "Collection",
             "IsPartOf": {
                 "TermURL": "snomed:1234",
                 "Label": "Imaginary tool"
@@ -62,6 +66,7 @@
                 "TermURL": "nb:Assessment",
                 "Label": "Assessment tool"
             },
+            "VariableType": "Collection",
             "IsPartOf": {
                 "TermURL": "snomed:1234",
                 "Label": "Imaginary tool"
@@ -76,6 +81,7 @@
                 "TermURL": "nb:Assessment",
                 "Label": "Assessment tool"
             },
+            "VariableType": "Collection",
             "IsPartOf": {
                 "TermURL": "snomed:4321",
                 "Label": "A different imaginary tool"

--- a/tests/data/example9.json
+++ b/tests/data/example9.json
@@ -5,8 +5,7 @@
             "IsAbout": {
                 "TermURL": "nb:ParticipantID",
                 "Label": "Unique participant identifier"
-            },
-            "Identifies": "participant"
+            }
         }
     },
     "session_id": {
@@ -15,8 +14,7 @@
             "IsAbout": {
                 "TermURL": "nb:SessionID",
                 "Label": "Unique session identifier"
-            },
-            "Identifies": "session"
+            }
         }
     },
     "group": {

--- a/tests/data/example_invalid.json
+++ b/tests/data/example_invalid.json
@@ -4,7 +4,8 @@
         "Annotations": {
             "IsAbout": {
                 "Label": "Unique participant identifier"
-            }
+            },
+            "VariableType": "Identifier"
         }
     },
     "session_id": {
@@ -12,7 +13,8 @@
         "Annotations": {
             "IsAbout": {
                 "Label": "Unique session identifier"
-            }
+            },
+            "VariableType": "Identifier"
         }
     },
     "group": {
@@ -32,7 +34,8 @@
                 "CTRL": {
                     "Label": "Healthy Control"
                 }
-            }
+            },
+            "VariableType": "Categorical"
         }
     }
 }

--- a/tests/data/example_invalid.json
+++ b/tests/data/example_invalid.json
@@ -4,8 +4,7 @@
         "Annotations": {
             "IsAbout": {
                 "Label": "Unique participant identifier"
-            },
-            "Identifies": "participant"
+            }
         }
     },
     "session_id": {
@@ -13,8 +12,7 @@
         "Annotations": {
             "IsAbout": {
                 "Label": "Unique session identifier"
-            },
-            "Identifies": "session"
+            }
         }
     },
     "group": {

--- a/tests/data/example_invalid_json.json
+++ b/tests/data/example_invalid_json.json
@@ -5,8 +5,7 @@
       "IsAbout": {
         "TermURL": "nb:ParticipantID",
         "Label": "Unique participant identifier"
-      },
-      "Identifies": "participant"
+      }
     }
   },
   "session_id": {
@@ -15,8 +14,7 @@
       "IsAbout": {
         "TermURL": "nb:SessionID",
         "Label": "Unique session identifier"
-      },
-      "Identifies": "session"
+      }
     }
   },
   "group": {

--- a/tests/data/example_invalid_json.json
+++ b/tests/data/example_invalid_json.json
@@ -5,7 +5,8 @@
       "IsAbout": {
         "TermURL": "nb:ParticipantID",
         "Label": "Unique participant identifier"
-      }
+      },
+      "VariableType": "Identifier"
     }
   },
   "session_id": {
@@ -14,7 +15,8 @@
       "IsAbout": {
         "TermURL": "nb:SessionID",
         "Label": "Unique session identifier"
-      }
+      },
+      "VariableType": "Identifier"
     }
   },
   "group": {
@@ -37,7 +39,8 @@
           "TermURL": "ncit:C94342",
           "Label": "Healthy Control"
         }
-      }
+      },
+      "VariableType": "Categorical"
     }
   },
 }

--- a/tests/data/example_iso88591.json
+++ b/tests/data/example_iso88591.json
@@ -5,8 +5,7 @@
       "IsAbout": {
         "TermURL": "nb:ParticipantID",
         "Label": "Unique participant identifier"
-      },
-      "Identifies": "participant"
+      }
     }
   },
   "session_id": {
@@ -15,8 +14,7 @@
       "IsAbout": {
         "TermURL": "nb:SessionID",
         "Label": "Unique session identifier"
-      },
-      "Identifies": "session"
+      }
     }
   },
   "âge_des_participants": {

--- a/tests/data/example_iso88591.json
+++ b/tests/data/example_iso88591.json
@@ -5,7 +5,8 @@
       "IsAbout": {
         "TermURL": "nb:ParticipantID",
         "Label": "Unique participant identifier"
-      }
+      },
+      "VariableType": "Identifier"
     }
   },
   "session_id": {
@@ -14,7 +15,8 @@
       "IsAbout": {
         "TermURL": "nb:SessionID",
         "Label": "Unique session identifier"
-      }
+      },
+      "VariableType": "Identifier"
     }
   },
   "âge_des_participants": {
@@ -27,7 +29,8 @@
       "Format": {
         "TermURL": "nb:FromISO8601",
         "Label": "A period of time defined according to the ISO8601 standard"
-      }
+      },
+      "VariableType": "Continuous"
     }
   }
 }

--- a/tests/unit/test_pheno_utils.py
+++ b/tests/unit/test_pheno_utils.py
@@ -18,8 +18,7 @@ from bagel.utilities import pheno_utils
                         "IsAbout": {
                             "TermURL": "nb:ParticipantID",
                             "Label": "Unique participant identifier",
-                        },
-                        "Identifies": "participant",
+                        }
                     },
                 },
                 "sex": {
@@ -40,8 +39,7 @@ from bagel.utilities import pheno_utils
                         "IsAbout": {
                             "TermURL": "nb:ParticipantID",
                             "Label": "Unique participant identifier",
-                        },
-                        "Identifies": "participant",
+                        }
                     },
                 },
                 "age": {
@@ -65,8 +63,7 @@ from bagel.utilities import pheno_utils
                         "IsAbout": {
                             "TermURL": "nb:ParticipantID",
                             "Label": "Unique participant identifier",
-                        },
-                        "Identifies": "participant",
+                        }
                     },
                 },
                 "age": {
@@ -147,8 +144,7 @@ def test_find_unsupported_namespaces_and_term_urls():
                 "IsAbout": {
                     "TermURL": "nb:ParticipantID",
                     "Label": "Unique participant identifier",
-                },
-                "Identifies": "participant",
+                }
             },
         },
         "group": {
@@ -419,8 +415,7 @@ def test_invalid_age_format(caplog, propagate_errors):
                     "IsAbout": {
                         "TermURL": "nb:ParticipantID",
                         "Label": "Unique participant identifier",
-                    },
-                    "Identifies": "participant",
+                    }
                 },
             },
             "age": {
@@ -441,8 +436,7 @@ def test_invalid_age_format(caplog, propagate_errors):
                     "IsAbout": {
                         "TermURL": "nb:ParticipantID",
                         "Label": "Unique participant identifier",
-                    },
-                    "Identifies": "participant",
+                    }
                 },
             },
             "age": {
@@ -463,8 +457,7 @@ def test_invalid_age_format(caplog, propagate_errors):
                     "IsAbout": {
                         "TermURL": "nb:ParticipantID",
                         "Label": "Unique participant identifier",
-                    },
-                    "Identifies": "participant",
+                    }
                 },
             },
             "age_iso8601": {
@@ -512,8 +505,7 @@ def test_format_and_transformation_schema_validation(
                         "IsAbout": {
                             "TermURL": "nb:ParticipantID",
                             "Label": "Unique participant identifier",
-                        },
-                        "Identifies": "participant",
+                        }
                     },
                 },
                 "age": {
@@ -534,8 +526,7 @@ def test_format_and_transformation_schema_validation(
                         "IsAbout": {
                             "TermURL": "nb:ParticipantID",
                             "Label": "Unique participant identifier",
-                        },
-                        "Identifies": "participant",
+                        }
                     },
                 },
                 "age": {
@@ -560,7 +551,6 @@ def test_format_and_transformation_schema_validation(
                             "TermURL": "nb:ParticipantID",
                             "Label": "Unique participant identifier",
                         },
-                        "Identifies": "participant",
                     },
                 },
                 "recruitment_age": {
@@ -582,7 +572,6 @@ def test_format_and_transformation_schema_validation(
                             "TermURL": "nb:ParticipantID",
                             "Label": "Unique participant identifier",
                         },
-                        "Identifies": "participant",
                     },
                 },
                 "recruitment_age": {
@@ -607,7 +596,6 @@ def test_format_and_transformation_schema_validation(
                             "TermURL": "nb:ParticipantID",
                             "Label": "Unique participant identifier",
                         },
-                        "Identifies": "participant",
                     },
                 },
                 "age_iso8601": {
@@ -639,7 +627,6 @@ def test_format_and_transformation_schema_validation(
                             "TermURL": "nb:ParticipantID",
                             "Label": "Unique participant identifier",
                         },
-                        "Identifies": "participant",
                     },
                 },
                 "age_iso8601": {

--- a/tests/unit/test_pheno_utils.py
+++ b/tests/unit/test_pheno_utils.py
@@ -275,7 +275,7 @@ def test_get_transformed_categorical_values(
             {
                 "column": {
                     "Annotations": {
-                        "IsAbout": {"TermURL": "something", "Labels": "other"},
+                        "IsAbout": {"TermURL": "something", "Label": "other"},
                         "Levels": {
                             "val1": {"TermURL": "something", "Label": "other"}
                         },
@@ -290,9 +290,9 @@ def test_get_transformed_categorical_values(
                 "column": {
                     "Levels": {"val1": "some description"},
                     "Annotations": {
-                        "IsAbout": {"TermURL": "something", "Labels": "other"}
+                        "IsAbout": {"TermURL": "something", "Label": "other"},
+                        "VariableType": "Categorical",
                     },
-                    "VariableType": "Categorical",
                 }
             },
             False,

--- a/tests/unit/test_pheno_utils.py
+++ b/tests/unit/test_pheno_utils.py
@@ -18,13 +18,15 @@ from bagel.utilities import pheno_utils
                         "IsAbout": {
                             "TermURL": "nb:ParticipantID",
                             "Label": "Unique participant identifier",
-                        }
+                        },
+                        "VariableType": "Identifier",
                     },
                 },
                 "sex": {
                     "Description": "Participant sex",
                     "Annotations": {
-                        "IsAbout": {"TermURL": "nb:Sex", "Label": ""}
+                        "IsAbout": {"TermURL": "nb:Sex", "Label": ""},
+                        "VariableType": "Categorical",
                     },
                 },
             },
@@ -39,7 +41,8 @@ from bagel.utilities import pheno_utils
                         "IsAbout": {
                             "TermURL": "nb:ParticipantID",
                             "Label": "Unique participant identifier",
-                        }
+                        },
+                        "VariableType": "Identifier",
                     },
                 },
                 "age": {
@@ -48,7 +51,8 @@ from bagel.utilities import pheno_utils
                         "IsAbout": {
                             "TermURL": "nb:Age",
                             "Label": "Chronological age",
-                        }
+                        },
+                        "VariableType": "Continuous",
                     },
                 },
             },
@@ -63,7 +67,8 @@ from bagel.utilities import pheno_utils
                         "IsAbout": {
                             "TermURL": "nb:ParticipantID",
                             "Label": "Unique participant identifier",
-                        }
+                        },
+                        "VariableType": "Identifier",
                     },
                 },
                 "age": {
@@ -78,6 +83,7 @@ from bagel.utilities import pheno_utils
                             "TermURL": "nb:FromEuro",
                             "Label": "european decimal value",
                         },
+                        "VariableType": "Continuous",
                     },
                 },
             },
@@ -126,7 +132,8 @@ def test_get_columns_with_annotations():
                 "IsAbout": {
                     "TermURL": "nb:ParticipantID",
                     "Label": "Unique participant identifier",
-                }
+                },
+                "VariableType": "Identifier",
             },
         },
     }
@@ -144,7 +151,8 @@ def test_find_unsupported_namespaces_and_term_urls():
                 "IsAbout": {
                     "TermURL": "nb:ParticipantID",
                     "Label": "Unique participant identifier",
-                }
+                },
+                "VariableType": "Identifier",
             },
         },
         "group": {
@@ -162,6 +170,7 @@ def test_find_unsupported_namespaces_and_term_urls():
                         "Label": "Healthy control",
                     },
                 },
+                "VariableType": "Categorical",
             },
         },
         "updrs_total": {
@@ -175,6 +184,7 @@ def test_find_unsupported_namespaces_and_term_urls():
                     "TermURL": "deprecatedvocab:1234",
                     "Label": "Unified Parkinson's Disease Rating Scale",
                 },
+                "VariableType": "Collection",
             },
         },
     }
@@ -269,6 +279,7 @@ def test_get_transformed_categorical_values(
                         "Levels": {
                             "val1": {"TermURL": "something", "Label": "other"}
                         },
+                        "VariableType": "Categorical",
                     }
                 }
             },
@@ -281,6 +292,7 @@ def test_get_transformed_categorical_values(
                     "Annotations": {
                         "IsAbout": {"TermURL": "something", "Labels": "other"}
                     },
+                    "VariableType": "Categorical",
                 }
             },
             False,
@@ -415,7 +427,8 @@ def test_invalid_age_format(caplog, propagate_errors):
                     "IsAbout": {
                         "TermURL": "nb:ParticipantID",
                         "Label": "Unique participant identifier",
-                    }
+                    },
+                    "VariableType": "Identifier",
                 },
             },
             "age": {
@@ -426,6 +439,7 @@ def test_invalid_age_format(caplog, propagate_errors):
                         "TermURL": "nb:FromEuro",
                         "Label": "european decimal value",
                     },
+                    "VariableType": "Continuous",
                 },
             },
         },
@@ -436,7 +450,8 @@ def test_invalid_age_format(caplog, propagate_errors):
                     "IsAbout": {
                         "TermURL": "nb:ParticipantID",
                         "Label": "Unique participant identifier",
-                    }
+                    },
+                    "VariableType": "Identifier",
                 },
             },
             "age": {
@@ -447,6 +462,7 @@ def test_invalid_age_format(caplog, propagate_errors):
                         "TermURL": "nb:FromEuro",
                         "Label": "european decimal value",
                     },
+                    "VariableType": "Continuous",
                 },
             },
         },
@@ -457,7 +473,8 @@ def test_invalid_age_format(caplog, propagate_errors):
                     "IsAbout": {
                         "TermURL": "nb:ParticipantID",
                         "Label": "Unique participant identifier",
-                    }
+                    },
+                    "VariableType": "Identifier",
                 },
             },
             "age_iso8601": {
@@ -468,6 +485,7 @@ def test_invalid_age_format(caplog, propagate_errors):
                         "TermURL": "nb:FromISO8601",
                         "Label": "period of time defined according to the ISO8601 standard",
                     },
+                    "VariableType": "Continuous",
                 },
             },
             "age": {
@@ -478,6 +496,7 @@ def test_invalid_age_format(caplog, propagate_errors):
                         "TermURL": "nb:FromFloat",
                         "Label": "float value",
                     },
+                    "VariableType": "Continuous",
                 },
             },
         },
@@ -505,7 +524,8 @@ def test_format_and_transformation_schema_validation(
                         "IsAbout": {
                             "TermURL": "nb:ParticipantID",
                             "Label": "Unique participant identifier",
-                        }
+                        },
+                        "VariableType": "Identifier",
                     },
                 },
                 "age": {
@@ -516,6 +536,7 @@ def test_format_and_transformation_schema_validation(
                             "TermURL": "nb:FromEuro",
                             "Label": "european decimal value",
                         },
+                        "VariableType": "Continuous",
                     },
                 },
             },
@@ -526,7 +547,8 @@ def test_format_and_transformation_schema_validation(
                         "IsAbout": {
                             "TermURL": "nb:ParticipantID",
                             "Label": "Unique participant identifier",
-                        }
+                        },
+                        "VariableType": "Identifier",
                     },
                 },
                 "age": {
@@ -537,6 +559,7 @@ def test_format_and_transformation_schema_validation(
                             "TermURL": "nb:FromEuro",
                             "Label": "european decimal value",
                         },
+                        "VariableType": "Continuous",
                     },
                 },
             },
@@ -551,6 +574,7 @@ def test_format_and_transformation_schema_validation(
                             "TermURL": "nb:ParticipantID",
                             "Label": "Unique participant identifier",
                         },
+                        "VariableType": "Identifier",
                     },
                 },
                 "recruitment_age": {
@@ -561,6 +585,7 @@ def test_format_and_transformation_schema_validation(
                             "TermURL": "nb:FromEuro",
                             "Label": "european decimal value",
                         },
+                        "VariableType": "Continuous",
                     },
                 },
             },
@@ -572,6 +597,7 @@ def test_format_and_transformation_schema_validation(
                             "TermURL": "nb:ParticipantID",
                             "Label": "Unique participant identifier",
                         },
+                        "VariableType": "Identifier",
                     },
                 },
                 "recruitment_age": {
@@ -582,6 +608,7 @@ def test_format_and_transformation_schema_validation(
                             "TermURL": "nb:FromEuro",
                             "Label": "european decimal value",
                         },
+                        "VariableType": "Continuous",
                     },
                 },
             },
@@ -596,6 +623,7 @@ def test_format_and_transformation_schema_validation(
                             "TermURL": "nb:ParticipantID",
                             "Label": "Unique participant identifier",
                         },
+                        "VariableType": "Identifier",
                     },
                 },
                 "age_iso8601": {
@@ -606,6 +634,7 @@ def test_format_and_transformation_schema_validation(
                             "TermURL": "nb:FromISO8601",
                             "Label": "period of time defined according to the ISO8601 standard",
                         },
+                        "VariableType": "Continuous",
                     },
                 },
                 "age": {
@@ -616,6 +645,7 @@ def test_format_and_transformation_schema_validation(
                             "TermURL": "nb:FromFloat",
                             "Label": "float value",
                         },
+                        "VariableType": "Continuous",
                     },
                 },
             },
@@ -627,6 +657,7 @@ def test_format_and_transformation_schema_validation(
                             "TermURL": "nb:ParticipantID",
                             "Label": "Unique participant identifier",
                         },
+                        "VariableType": "Identifier",
                     },
                 },
                 "age_iso8601": {
@@ -637,6 +668,7 @@ def test_format_and_transformation_schema_validation(
                             "TermURL": "nb:FromISO8601",
                             "Label": "period of time defined according to the ISO8601 standard",
                         },
+                        "VariableType": "Continuous",
                     },
                 },
                 "age": {
@@ -647,6 +679,7 @@ def test_format_and_transformation_schema_validation(
                             "TermURL": "nb:FromFloat",
                             "Label": "float value",
                         },
+                        "VariableType": "Continuous",
                     },
                 },
             },


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the Neurobagel PR process and other contributing guidelines, see https://neurobagel.org/contributing/CONTRIBUTING/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #473 
- Closes #491 
- See also https://github.com/neurobagel/neurobagel_examples/pull/69

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- Refactor `IdentifierNeurobagel` column model to remove `"Identifies"` key and avoid matching other types of columns
- Minor fixes to other column models
- Add required `VariableType` key to all column models in data dictionary model
- Update `is_column_categorical()` to use data dictionary model instead of checking only for `"Levels"`

<!-- To be checked off by reviewers -->
## Checklist
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING#pull-request-guidelines) for more info)_
- [x] PR has a label for the release changelog or `skip-release` (to be applied by maintainers only)
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.

## Summary by Sourcery

Remove the deprecated "Identifies" key from identifier column schema, update the IdentifierNeurobagel model to only require "IsAbout", strengthen schema validation, and align tests and fixtures with the new format

Enhancements:
- Redefine IdentifierNeurobagel to inherit from BaseModel with only an "IsAbout" field and forbid extra keys
- Extend DataDictionary schema to accept the base Column type and enforce "Units" as required for ContinuousColumn

Tests:
- Remove all references to "Identifies" from unit tests and JSON fixtures

## Summary by Sourcery

Replace the deprecated "Identifies" annotation with a new required "VariableType" field in all Neurobagel schema models, strengthen Pydantic validation rules, expand the DataDictionary type union, and update utility logic to reflect these changes.

New Features:
- Add a required "VariableType" field to IdentifierNeurobagel, CategoricalNeurobagel, ContinuousNeurobagel, and ToolNeurobagel models

Enhancements:
- Redefine IdentifierNeurobagel to inherit directly from BaseModel with only an IsAbout field and forbid extra keys
- Make the Units field mandatory in ContinuousColumn and include the base Column type in the DataDictionary schema union
- Use Pydantic model validation to detect categorical columns instead of inspecting the "Levels" key

Tests:
- Update unit tests and JSON fixtures to remove all references to "Identifies" and use "VariableType"
- Fix field alias typo in categorical values tests from "Labels" to "Label"