### PR TITLE
[FIX] Exit gracefully when `bids2tsv` finds no valid NIfTI files

### DIFF
--- a/bagel/bids_table_model.py
+++ b/bagel/bids_table_model.py
@@ -74,5 +74,6 @@ model = pa.DataFrameSchema(
             ],
             nullable=False,
         ),
-    }
+    },
+    strict="filter",
 )

--- a/bagel/cli.py
+++ b/bagel/cli.py
@@ -127,6 +127,15 @@ def bids2tsv(
         nii_records["suffix"].isin(bids_table_model.BIDS_SUPPORTED_SUFFIXES)
     ].copy()
 
+    if dataset_df.empty:
+        log_error(
+            logger,
+            f"No NIfTI files with supported BIDS suffixes were found in {bids_dir}. "
+            "A BIDS metadata table could not be generated. "
+            "Please ensure your dataset includes at least one NIfTI file (.nii/.nii.gz) with a supported BIDS suffix "
+            "(see https://bids-specification.readthedocs.io/en/stable/).",
+        )
+
     dataset_df["path"] = dataset_df.apply(
         lambda row: (Path(row["root"]) / row["path"]).as_posix(), axis=1
     )

--- a/bagel/cli.py
+++ b/bagel/cli.py
@@ -370,7 +370,7 @@ def bids(
         ...,
         "--bids-table",
         "-b",
-        help="The path to a .tsv file containing the BIDS metadata for image files including 'sub', 'ses', 'suffix', and 'path' columns. "
+        help="The path to a .tsv file containing the BIDS metadata for NIfTI image files including 'sub', 'ses', 'suffix', and 'path' columns. "
         "This file can be created using the bagel bids2tsv command.",
         exists=True,
         file_okay=True,
@@ -384,7 +384,7 @@ def bids(
         "--dataset-source-dir",
         "-s",
         callback=bids_utils.check_absolute_path,
-        help="The absolute path to the root directory of the dataset at the source location/file server. "
+        help="The absolute path to the root directory of the BIDS dataset at the source location/file server. "
         "If provided, this path will be combined with the subject and session IDs from the BIDS table "
         "to create absolute source paths to the imaging data for each subject and session.",
         exists=False,

--- a/tests/integration/test_bids2tsv.py
+++ b/tests/integration/test_bids2tsv.py
@@ -99,9 +99,17 @@ def test_BIDS_unsupported_suffixes_filtered_out(
     assert result.exit_code == 0
 
 
+@pytest.mark.parametrize(
+    "no_nii_dataset",
+    [
+        "eeg_cbm",
+        "micr_SEM",
+    ],
+)
 def test_exits_gracefully_if_no_nii_files_in_bids_directory(
     runner,
     bids_path,
+    no_nii_dataset,
     default_bids2tsv_output_path,
     propagate_errors,
     caplog,
@@ -112,7 +120,7 @@ def test_exits_gracefully_if_no_nii_files_in_bids_directory(
         [
             "bids2tsv",
             "--bids-dir",
-            bids_path / "eeg_cbm",
+            bids_path / no_nii_dataset,
             "--output",
             default_bids2tsv_output_path,
         ],

--- a/tests/integration/test_bids2tsv.py
+++ b/tests/integration/test_bids2tsv.py
@@ -97,3 +97,30 @@ def test_BIDS_unsupported_suffixes_filtered_out(
         ],
     )
     assert result.exit_code == 0
+
+
+def test_exits_gracefully_if_no_nii_files_in_bids_directory(
+    runner,
+    bids_path,
+    default_bids2tsv_output_path,
+    propagate_errors,
+    caplog,
+):
+    """Test that bids2tsv exits with an informative error if no NIfTI files are found in the BIDS directory."""
+    result = runner.invoke(
+        bagel,
+        [
+            "bids2tsv",
+            "--bids-dir",
+            bids_path / "eeg_cbm",
+            "--output",
+            default_bids2tsv_output_path,
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert not default_bids2tsv_output_path.exists()
+    assert len(caplog.records) == 1
+    assert (
+        "No NIfTI files with supported BIDS suffixes were found" in caplog.text
+    )


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the Neurobagel PR process and other contributing guidelines, see https://neurobagel.org/contributing/CONTRIBUTING/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Fixes #545 
- Closes #516

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- When a BIDS directory contains no `.nii/.nii.gz` files with valid suffixes, emit an informative error and exit
- In the `bids` command, filter out (and ignore) columns in the BIDS metadata table that aren't in the schema

<!-- To be checked off by reviewers -->
## Checklist
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING#pull-request-guidelines) for more info)_
- [x] PR has a label for the release changelog or `skip-release` (to be applied by maintainers only)
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.

## Summary by Sourcery

Handle cases where bids2tsv finds no supported NIfTI files by logging an error and exiting without generating output; enforce strict filtering in the BIDS table schema; and add an integration test for this scenario.

Bug Fixes:
- Exit bids2tsv with an informative error when no NIfTI files with supported BIDS suffixes are found

Enhancements:
- Enable strict filtering in the BIDS table pandera schema to drop unexpected columns

Tests:
- Add an integration test to verify bids2tsv fails gracefully when no NIfTI files are present