### PR TITLE
[FIX] Include `.git` for `nightly` Docker build to enable version detection

### DIFF
--- a/Dockerfile.nightly.dockerignore
+++ b/Dockerfile.nightly.dockerignore
@@ -1,0 +1,46 @@
+# python cache
+__pycache__/**/*
+__pycache__
+*.pyc
+
+# python distribution
+build/**/*
+build
+dist/**/*
+dist
+bagelbids.egg-info/**/*
+bagelbids.egg-info
+.eggs/**/*
+.eggs
+
+.editorconfig
+# **/.git
+**/.github
+**/.gitignore
+**/.vscode
+**/coverage
+**/.env
+**/.aws
+**/.ssh
+**/.DS_Store
+**/venv
+**/env
+Dockerfile
+Dockerfile.nightly
+
+# other configuration files and scripts
+.autorc
+.pre-commit-config.yaml
+generate_nb_vocab_file.py
+
+# documentation
+CHANGELOG.md
+CITATION.cff
+LICENSE
+README.md
+
+# testing
+tests
+
+# standalone scripts
+helper_scripts


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->


<!---
Below is a suggested pull request template. Feel free to add more details you feel are relevant/necessary.

For more info on the Neurobagel PR process and other contributing guidelines, see https://neurobagel.org/contributing/CONTRIBUTING/.
-->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Fixes #582 

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
Changes proposed in this pull request:

- Add custom dockerignore file for `nightly` build that contains same contents as .dockerignore **except** .git
  - followed dockerignore file naming guidelines from https://docs.docker.com/build/concepts/context/#filename-and-location

<!-- To be checked off by reviewers -->
## Checklist
_This section is for the PR reviewer_

- [x] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING#pull-request-guidelines) for more info)_
- [x] PR has a label for the release changelog or `skip-release` (to be applied by maintainers only)
- [x] PR links to GitHub issue with mention `Closes #XXXX`
- [x] Tests pass
- [x] Checks pass

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.

## Summary by Sourcery

Bug Fixes:
- Enable version detection in nightly Docker builds by preserving the .git directory in the build context via a custom dockerignore file.