### PR TITLE
[FIX] Set explicit wf permissions

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -11,6 +11,8 @@ jobs:
   codespell:
     name: Check for spelling errors
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Potential fix for [https://github.com/neurobagel/bagel-cli/security/code-scanning/16](https://github.com/neurobagel/bagel-cli/security/code-scanning/16)

To fix this problem, you should add a `permissions` block to limit the GITHUB_TOKEN used by this job or workflow. Since the only operations being performed here are checking out code and running Codespell (a spellchecker for files), you only need read permission for repository contents. The recommended, minimal fix is to add the following block at the appropriate level:
- Add `permissions: contents: read` to the workflow YAML, either at the root (to affect all jobs) or under the specific job (`codespell`).
Adding at the job level keeps the scope tightly focused. Insert this directly before `steps:`, typically after the existing job configuration lines.

No new methods, imports, or definitions are required. The fix is purely a change to the YAML file's structure.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Restrict GITHUB_TOKEN permissions in the codespell workflow to only read repository contents to address code scanning alert