### PR TITLE
[FIX] Report all JSON Schema validation errors at once in pheno_utils

### DIFF
--- a/bagel/cli.py
+++ b/bagel/cli.py
@@ -880,3 +880,7 @@ def harmonize_pheno(
 
     harmonized_pheno_df.to_csv(output, sep="\t", index=False)
     logger.info(f"Saved harmonized table to:  {output}")
+
+
+if __name__ == "__main__":
+    bagel()

--- a/bagel/cli.py
+++ b/bagel/cli.py
@@ -882,5 +882,5 @@ def harmonize_pheno(
     logger.info(f"Saved harmonized table to:  {output}")
 
 
-if __name__ == "__main__":
+if __name__ == "__main__":  # pragma: no cover
     bagel()

--- a/bagel/utilities/pheno_utils.py
+++ b/bagel/utilities/pheno_utils.py
@@ -480,25 +480,23 @@ def construct_dictionary_schema_for_validation() -> dict:
 
 
 def validate_data_dict(data_dict: dict, config: str | None) -> None:
-    try:
-        jsonschema.validate(
-            data_dict, construct_dictionary_schema_for_validation()
+    validator = jsonschema.Draft7Validator(
+        construct_dictionary_schema_for_validation()
+    )
+    errors = list(validator.iter_errors(data_dict))
+
+    if errors:
+        err_messages = "\n".join(
+            f"- {e.path[-1] if e.path else 'Entire document'}: {e.message}"
+            for e in errors
         )
-    except jsonschema.ValidationError as e:
-        # TODO: When *every* item in an input JSON is not schema valid,
-        # jsonschema.validate will raise a ValidationError for only *one* item among them.
-        # Weirdly, the item that is chosen can vary, possibly due to jsonschema internally processing/validating
-        # items in an inconsistent order.
-        # You can reproduce this by running `bagel pheno` on the example_invalid input pair.
-        # This isn't necessarily a problem as the error will not be wrong, but if we care about
-        # returning ALL invalid items, we may want to use something like a Draft7Validator instance instead.
-        # NOTE: If the validation error occurs at the root level (i.e., the entire JSON object fails),
-        # e.path may be empty. We have a backup descriptor "Entire document" for the offending item in this case.
+        # Escape Rich markup brackets in the messages
+        err_messages = err_messages.replace("[", "\\[").replace("]", "\\]")
+
         log_error(
             logger,
-            "The data dictionary is not a valid Neurobagel data dictionary. "
-            f"Entry that failed validation: {e.path[-1] if e.path else 'Entire document'}\n"
-            f"Details: {e.message}\n"
+            f"The data dictionary is not a valid Neurobagel data dictionary. Found {len(errors)} error(s):\n"
+            f"{err_messages}\n"
             "[italic]TIP: Ensure each annotated column contains an 'Annotations' key.[/italic]",
         )
 


### PR DESCRIPTION
<!--- Until this PR is ready for review, you can include [WIP] in the title, or create a draft PR. -->

<!-- 
Please indicate after the # which issue you're closing with this PR, if applicable.
If the PR closes multiple issues, include "closes" before each one is listed.
You can also link to other issues if necessary, e.g. "See also #1234".

https://help.github.com/articles/closing-issues-using-keywords
-->
- Closes #338

<!-- 
Please give a brief overview of what has changed or been added in the PR.
This can include anything specific the maintainers should be looking for when they review the PR.
-->
### Changes proposed in this pull request:

- Replaced `jsonschema.validate()` with `jsonschema.Draft7Validator.iter_errors()` in `bagel/utilities/pheno_utils.py:validate_data_dict()` to collect all schema validation errors lazily instead of failing fast on the first error.
- Aggregated the validation errors into a single formatted string to log them all at once at the terminal.
- Added escaping for `[` and `]` characters in the generated error message string to prevent the `rich` logger handler from treating them as markup tags and swallowing details about the schema violations.
- Added an `if __name__ == "__main__":` execution block to [bagel/cli.py](cci:7://file:///c:/Users/dhanu/Desktop/neurobagel%20repo/bagel-cli/bagel/cli.py:0:0-0:0) to allow the CLI to be executed as a module (`python -m bagel.cli`) for easier local testing and debugging.

### Visual Proof

**Before:**

<img width="1031" height="336" alt="Screenshot 2026-03-06 154436" src="https://github.com/user-attachments/assets/aad6724b-c139-405e-8fc3-7aaeba606afb" />


**After:**

<img width="1040" height="532" alt="Screenshot 2026-03-06 154151" src="https://github.com/user-attachments/assets/7df2ca28-4e40-4912-a0b1-fd2b83e50e12" />


<!-- To be checked off by reviewers -->
## Checklist
_This section is for the PR reviewer_

- [ ] PR has an interpretable title with a prefix (`[ENH]`, `[FIX]`, `[REF]`, `[TST]`, `[CI]`, `[MNT]`, `[INF]`, `[MODEL]`, `[DOC]`) _(see our [Contributing Guidelines](https://neurobagel.org/contributing/CONTRIBUTING#pull-request-guidelines) for more info)_
- [ ] PR has a label for the release changelog or `skip-release` (to be applied by maintainers only)
- [ ] PR links to GitHub issue with mention `Closes #XXXX`
- [ ] Tests pass
- [ ] Checks pass

For new features:
- [ ] Tests have been added

For bug fixes:
- [ ] There is at least one test that would fail under the original bug conditions.

## Summary by Sourcery

Report all JSON Schema validation errors in phenotype data dictionaries and enable running the CLI module directly for local testing.

Bug Fixes:
- Collect and report all JSON Schema validation errors for phenotype data dictionaries instead of failing on the first one.
- Escape square brackets in validation error messages to prevent the rich logger from misinterpreting them as markup and hiding details.

Enhancements:
- Allow executing the bagel CLI via `python -m bagel.cli` by adding a module entry point block.